### PR TITLE
修复过载供电仪保存时重复标脏

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/blockentity/OverloadedPowerSupplyBlockEntity.java
+++ b/src/main/java/com/moakiee/ae2lt/blockentity/OverloadedPowerSupplyBlockEntity.java
@@ -605,7 +605,10 @@ public class OverloadedPowerSupplyBlockEntity extends AENetworkedBlockEntity
 
     @Override
     public void saveAdditional(CompoundTag data, HolderLookup.Provider registries) {
-        logic.persistCellCache();
+        // Only copy the cell's in-memory state into its ItemStack before the
+        // inventory is serialized. Do not call saveChanges() from this path:
+        // the chunk is already being saved, and re-marking it dirty here makes
+        // /save-all flush pick it up again in the next dirty pass.
         AppFluxBridge.persistCellStorage(cachedCellView);
         super.saveAdditional(data, registries);
         data.putString(TAG_MODE, mode.name());


### PR DESCRIPTION
保存 NBT 时只同步电池 ItemStack 状态,避免 persistCellCache 通过回调再次 saveChanges 导致 /save-all flush 反复保存同一 chunk。