### PR TITLE
fix: register IN_WORLD_GRID_NODE_HOST for Extended Overloaded Pattern Provider

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/AE2LightningTech.java
+++ b/src/main/java/com/moakiee/ae2lt/AE2LightningTech.java
@@ -360,6 +360,11 @@ public class AE2LightningTech {
 
         event.registerBlockEntity(
                 AECapabilities.IN_WORLD_GRID_NODE_HOST,
+                ModBlockEntities.EXTENDED_OVERLOADED_PATTERN_PROVIDER.get(),
+                (blockEntity, context) -> (IInWorldGridNodeHost) blockEntity);
+
+        event.registerBlockEntity(
+                AECapabilities.IN_WORLD_GRID_NODE_HOST,
                 ModBlockEntities.OVERLOADED_INTERFACE.get(),
                 (blockEntity, context) -> (IInWorldGridNodeHost) blockEntity);
 


### PR DESCRIPTION
Problem
    The Extended Overloaded Pattern Provider block cannot connect to ME cables.

    Root Cause
    In AE2LightningTech.java, the capability registration section registers
    AECapabilities.IN_WORLD_GRID_NODE_HOST for OVERLOADED_PATTERN_PROVIDER
    but not for EXTENDED_OVERLOADED_PATTERN_PROVIDER. Without this capability
    exposure, AE2's cable system cannot detect the block's grid node.

    Fix
    Added the missing registerBlockEntity call for EXTENDED_OVERLOADED_PATTERN_PROVIDER,
    placed directly after the existing OVERLOADED_PATTERN_PROVIDER registration.

    Verification
    - ./gradlew compileJava passes (BUILD SUCCESSFUL)
    - Minimal change: 5 lines added, no other files touched.