### PR TITLE
fix(celestweave): spurious equip sound in creative inventory #20

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/celestweave/ArmorEnergyBuffer.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/ArmorEnergyBuffer.java
@@ -1,5 +1,9 @@
 package com.moakiee.ae2lt.celestweave;
 
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
@@ -14,6 +18,21 @@ import com.moakiee.ae2lt.logic.energy.AppFluxBridge;
 import com.moakiee.ae2lt.registry.ModDataComponents;
 
 public final class ArmorEnergyBuffer {
+
+    /**
+     * Authoritative runtime energy, keyed by armor UUID. The
+     * {@code CELESTWEAVE_ENERGY_BUFFER} data component is NOT mutated on
+     * every inventory tick — every such mutation dirties the ItemStack
+     * and causes Minecraft to resync the armor slot to the client, which
+     * unconditionally calls {@code LivingEntity.onEquipItem} → plays
+     * {@code ARMOR_EQUIP_GENERIC} even though only the energy value
+     * changed (issue #20, "after charging" variant).
+     *
+     * <p>Call {@link #flushToStack} to persist the runtime value back to
+     * the data component before logout / clone / save.
+     */
+    private static final ConcurrentMap<UUID, Long> RUNTIME_ENERGY = new ConcurrentHashMap<>();
+
     private ArmorEnergyBuffer() {
     }
 
@@ -21,7 +40,23 @@ public final class ArmorEnergyBuffer {
         return read(stack, null);
     }
 
+    /**
+     * Read the current energy. Prefer the runtime map; fall back to the
+     * data component for newly-loaded armor that hasn't entered a
+     * player's inventory yet (e.g. freshly crafted or picked up from
+     * the ground).
+     */
     public static long read(ItemStack stack, HolderLookup.Provider registries) {
+        if (stack == null || stack.isEmpty()) {
+            return 0L;
+        }
+        UUID id = CelestweaveArmorState.getArmorId(stack);
+        if (id != null) {
+            Long runtime = RUNTIME_ENERGY.get(id);
+            if (runtime != null) {
+                return Math.max(0L, Math.min(capacity(stack, registries), runtime));
+            }
+        }
         Long value = stack.get(ModDataComponents.CELESTWEAVE_ENERGY_BUFFER.get());
         return Math.max(0L, Math.min(capacity(stack, registries), value == null ? 0L : value));
     }
@@ -38,11 +73,18 @@ public final class ArmorEnergyBuffer {
         write(stack, null, value);
     }
 
+    /**
+     * Store energy in the runtime map only — never in the
+     * {@code CELESTWEAVE_ENERGY_BUFFER} data component.
+     * See the class-level javadoc for the rationale.
+     */
     public static void write(ItemStack stack, HolderLookup.Provider registries, long value) {
         if (stack == null || stack.isEmpty()) {
             return;
         }
-        stack.set(ModDataComponents.CELESTWEAVE_ENERGY_BUFFER.get(), Math.max(0L, Math.min(capacity(stack, registries), value)));
+        UUID id = CelestweaveArmorState.ensureArmorId(stack);
+        long clamped = Math.max(0L, Math.min(capacity(stack, registries), value));
+        RUNTIME_ENERGY.put(id, clamped);
     }
 
     public static void clamp(ItemStack stack) {
@@ -51,6 +93,41 @@ public final class ArmorEnergyBuffer {
 
     public static void clamp(ItemStack stack, HolderLookup.Provider registries) {
         write(stack, registries, read(stack, registries));
+    }
+
+    /**
+     * Persist the runtime energy to the ItemStack data component.
+     * Call only on save / logout / clone — never during
+     * {@code inventoryTick}, because that is exactly what triggers the
+     * spurious equip sound (see class-level javadoc).
+     */
+    public static void flushToStack(ItemStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return;
+        }
+        UUID id = CelestweaveArmorState.getArmorId(stack);
+        if (id == null) {
+            return;
+        }
+        Long runtime = RUNTIME_ENERGY.get(id);
+        if (runtime == null) {
+            return;
+        }
+        Long current = stack.get(ModDataComponents.CELESTWEAVE_ENERGY_BUFFER.get());
+        if (current != null && current == runtime) {
+            return;
+        }
+        stack.set(ModDataComponents.CELESTWEAVE_ENERGY_BUFFER.get(), runtime);
+    }
+
+    /**
+     * Drop the runtime cache entry for an armor UUID (e.g. after
+     * logout / clone or when the armor is discarded).
+     */
+    public static void clearRuntime(UUID armorId) {
+        if (armorId != null) {
+            RUNTIME_ENERGY.remove(armorId);
+        }
     }
 
     public static boolean tryConsume(ItemStack stack, ServerPlayer player, long amount) {

--- a/src/main/java/com/moakiee/ae2lt/celestweave/CelestweaveArmorUtilityHandler.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/CelestweaveArmorUtilityHandler.java
@@ -296,6 +296,9 @@ public final class CelestweaveArmorUtilityHandler {
                 EquipmentSlot.FEET)) {
             ItemStack armor = player.getItemBySlot(slot);
             if (!armor.isEmpty() && armor.getItem() instanceof BaseCelestweaveArmorItem) {
+                // Flush the runtime energy back to the data component so the
+                // armor's energy value survives logout / clone (issue #20).
+                ArmorEnergyBuffer.flushToStack(armor);
                 CelestweaveArmorState.clearTransientRuntimeAndCaches(armor);
             }
         }

--- a/src/main/java/com/moakiee/ae2lt/celestweave/state/ArmorPersistentData.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/state/ArmorPersistentData.java
@@ -63,10 +63,21 @@ public final class ArmorPersistentData {
         setContainer(armor, container(armor).withCapacity(Optional.of(Math.max(0L, capacityFe))));
     }
 
+    /**
+     * Returns the installed structural core as a plain ItemStack.
+     * The data component stores a {@link StructuralCoreWrapper} so that
+     * {@code equals} uses {@code ItemStack.matches} rather than reference
+     * identity (issue #20 — see the wrapper's javadoc).
+     */
     public static ItemStack structuralCore(ItemStack armor) {
-        return armor.getOrDefault(ModDataComponents.CELESTWEAVE_STRUCTURAL_CORE.get(), ItemStack.EMPTY).copyWithCount(1);
+        return armor.getOrDefault(ModDataComponents.CELESTWEAVE_STRUCTURAL_CORE.get(), StructuralCoreWrapper.EMPTY).stack().copyWithCount(1);
     }
 
+    /**
+     * Sets the structural core. The core is wrapped in a {@link StructuralCoreWrapper}
+     * before storage so that data-component equality checks use content-based
+     * comparison ({@code ItemStack.matches}) rather than reference identity.
+     */
     public static void setStructuralCore(ItemStack armor, ItemStack stack) {
         if (armor == null || armor.isEmpty()) {
             return;
@@ -74,7 +85,7 @@ public final class ArmorPersistentData {
         if (stack == null || stack.isEmpty()) {
             armor.remove(ModDataComponents.CELESTWEAVE_STRUCTURAL_CORE.get());
         } else {
-            armor.set(ModDataComponents.CELESTWEAVE_STRUCTURAL_CORE.get(), stack.copyWithCount(1));
+            armor.set(ModDataComponents.CELESTWEAVE_STRUCTURAL_CORE.get(), new StructuralCoreWrapper(stack));
         }
     }
 

--- a/src/main/java/com/moakiee/ae2lt/celestweave/state/CelestweaveModuleContainer.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/state/CelestweaveModuleContainer.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -78,7 +79,6 @@ public record CelestweaveModuleContainer(
         return new CelestweaveModuleContainer(Optional.ofNullable(id), modules, toggles, submoduleData, energyModuleCapacityFe);
     }
 
-    /** Replace the module list and the (re-derived) capacity cache together; they always change as a unit. */
     public CelestweaveModuleContainer withModules(List<ItemStack> newModules, Optional<Long> capacityFe) {
         return new CelestweaveModuleContainer(armorId, newModules, toggles, submoduleData, capacityFe);
     }
@@ -95,13 +95,103 @@ public record CelestweaveModuleContainer(
         return new CelestweaveModuleContainer(armorId, modules, toggles, submoduleData, capacityFe);
     }
 
+    // Custom equals/hashCode — see javadoc below on why the record default is insufficient.
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CelestweaveModuleContainer other)) {
+            return false;
+        }
+        return Objects.equals(armorId, other.armorId)
+                && modulesEquals(modules, other.modules)
+                && Objects.equals(toggles, other.toggles)
+                && submoduleDataEquals(submoduleData, other.submoduleData)
+                && Objects.equals(energyModuleCapacityFe, other.energyModuleCapacityFe);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(armorId, modulesHash(modules), toggles, submoduleDataHash(submoduleData), energyModuleCapacityFe);
+    }
+
+    /**
+     * Compare two module lists by content. The record's auto-generated equals
+     * delegates to {@code List.equals} which calls {@code ItemStack.equals}.
+     * {@code ItemStack} does NOT override {@code equals} — two identical-looking
+     * copies returned by the network {@code STREAM_CODEC} are different objects
+     * and therefore never equal. This caused {@code isSameItemSameComponents} to
+     * always return {@code false} inside creative-mode inventory slot handling,
+     * which triggered repeated {@code ARMOR_EQUIP_GENERIC} (issue #20).
+     */
+    private static boolean modulesEquals(List<ItemStack> a, List<ItemStack> b) {
+        if (a == b) {
+            return true;
+        }
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (!ItemStack.matches(a.get(i), b.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int modulesHash(List<ItemStack> modules) {
+        int hash = 0;
+        for (ItemStack stack : modules) {
+            hash = 31 * hash + ItemStack.hashItemAndComponents(stack);
+        }
+        return hash;
+    }
+
+    /**
+     * Compare two submodule-data maps by content. {@code CompoundTag.equals}
+     * delegates to {@code Map.equals} which calls {@code Tag.equals} on each
+     * nested value. {@code Tag} does NOT override {@code equals}, so two
+     * CompoundTags with identical content but created via {@code copy()} are
+     * never equal. Use NBT string comparison to work around this (issue #20,
+     * "with core" variant — submodules are active only when the core is
+     * installed).
+     */
+    private static boolean submoduleDataEquals(Map<String, CompoundTag> a, Map<String, CompoundTag> b) {
+        if (a == b) {
+            return true;
+        }
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (var entry : a.entrySet()) {
+            CompoundTag bValue = b.get(entry.getKey());
+            if (bValue == null) {
+                return false;
+            }
+            if (!entry.getValue().toString().equals(bValue.toString())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int submoduleDataHash(Map<String, CompoundTag> data) {
+        int hash = 0;
+        for (var entry : data.entrySet()) {
+            hash = 31 * hash + entry.getKey().hashCode();
+            hash = 31 * hash + entry.getValue().toString().hashCode();
+        }
+        return hash;
+    }
+
     private static List<ItemStack> copyModules(List<ItemStack> modules) {
         if (modules == null || modules.isEmpty()) {
             return List.of();
         }
         return modules.stream()
                 .filter(stack -> stack != null && !stack.isEmpty())
-                .map(ItemStack::copy)
                 .toList();
     }
 
@@ -114,7 +204,7 @@ public record CelestweaveModuleContainer(
             if (entry.getKey() == null || entry.getKey().isBlank() || entry.getValue() == null) {
                 continue;
             }
-            copy.put(entry.getKey(), entry.getValue().copy());
+            copy.put(entry.getKey(), entry.getValue());
         }
         return Map.copyOf(copy);
     }

--- a/src/main/java/com/moakiee/ae2lt/celestweave/state/StructuralCoreWrapper.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/state/StructuralCoreWrapper.java
@@ -1,0 +1,47 @@
+package com.moakiee.ae2lt.celestweave.state;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Wraps an ItemStack for the {@code CELESTWEAVE_STRUCTURAL_CORE} data component.
+ * {@code ItemStack.equals} is {@code Object.equals} (reference), so two
+ * identical-looking copies from network deserialisation are never equal.
+ * This record's {@code equals} uses {@link ItemStack#matches} instead,
+ * fixing the same class of bug as {@link CelestweaveModuleContainer} (issue #20).
+ * 
+ * @author howxu &lt;dev@howxu.cn&gt;
+ */
+public record StructuralCoreWrapper(ItemStack stack) {
+
+    public static final StructuralCoreWrapper EMPTY = new StructuralCoreWrapper(ItemStack.EMPTY);
+
+    public static final Codec<StructuralCoreWrapper> CODEC =
+            ItemStack.OPTIONAL_CODEC.xmap(StructuralCoreWrapper::new, StructuralCoreWrapper::stack);
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, StructuralCoreWrapper> STREAM_CODEC =
+            ItemStack.OPTIONAL_STREAM_CODEC.map(StructuralCoreWrapper::new, StructuralCoreWrapper::stack);
+
+    public StructuralCoreWrapper {
+        stack = stack == null || stack.isEmpty() ? ItemStack.EMPTY : stack.copyWithCount(1);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StructuralCoreWrapper other)) {
+            return false;
+        }
+        return ItemStack.matches(stack, other.stack);
+    }
+
+    @Override
+    public int hashCode() {
+        return ItemStack.hashItemAndComponents(stack);
+    }
+}

--- a/src/main/java/com/moakiee/ae2lt/registry/ModDataComponents.java
+++ b/src/main/java/com/moakiee/ae2lt/registry/ModDataComponents.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 
 import com.moakiee.ae2lt.AE2LightningTech;
 import com.moakiee.ae2lt.celestweave.state.CelestweaveModuleContainer;
+import com.moakiee.ae2lt.celestweave.state.StructuralCoreWrapper;
 import com.moakiee.ae2lt.item.railgun.RailgunModuleEntries;
 import com.moakiee.ae2lt.item.railgun.RailgunSettings;
 
@@ -44,7 +45,8 @@ public final class ModDataComponents {
                             .persistent(CustomData.CODEC)
                             .networkSynchronized(CustomData.STREAM_CODEC));
 
-    /** Per-stack railgun module entries. */
+    /** Per-stack railgun module entries. The record has a custom equals that
+     * uses {@code ItemStack.matches} instead of reference comparison (issue #20). */
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<RailgunModuleEntries>>
             RAILGUN_MODULE_ENTRIES = DATA_COMPONENTS.registerComponentType(
                     "railgun_module_entries",
@@ -84,15 +86,21 @@ public final class ModDataComponents {
                             .persistent(Codec.LONG)
                             .networkSynchronized(ByteBufCodecs.VAR_LONG));
 
-    /** Structural core installed in one Celestweave armor piece. */
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<ItemStack>>
+    /** Structural core installed in one Celestweave armor piece. Wrapped in
+     * {@link StructuralCoreWrapper} so that data-component equality uses
+     * {@code ItemStack.matches} rather than reference identity (issue #20). */
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<StructuralCoreWrapper>>
             CELESTWEAVE_STRUCTURAL_CORE = DATA_COMPONENTS.registerComponentType(
                     "celestweave_structural_core",
                     builder -> builder
-                            .persistent(ItemStack.OPTIONAL_CODEC)
-                            .networkSynchronized(ItemStack.OPTIONAL_STREAM_CODEC));
+                            .persistent(StructuralCoreWrapper.CODEC)
+                            .networkSynchronized(StructuralCoreWrapper.STREAM_CODEC));
 
-    /** Per-stack FE energy buffer for v4 Celestweave armor pieces. */
+    /** Per-stack FE energy buffer for v4 Celestweave armor pieces.
+     * Runtime authoritative value lives in {@link com.moakiee.ae2lt.celestweave.ArmorEnergyBuffer#RUNTIME_ENERGY}
+     * so that every tick's energy fluctuation no longer dirties the ItemStack
+     * and triggers spurious equipment-change detection (issue #20 — the
+     * "after charging" variant). */
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Long>>
             CELESTWEAVE_ENERGY_BUFFER = DATA_COMPONENTS.registerComponentType(
                     "celestweave_energy_buffer",
@@ -100,14 +108,20 @@ public final class ModDataComponents {
                             .persistent(Codec.LONG)
                             .networkSynchronized(ByteBufCodecs.VAR_LONG));
 
-    /** Installed modules, toggles and per-submodule data for one Celestweave armor piece. */
+    /** Installed modules, toggles and per-submodule data for one Celestweave
+     * armor piece. The record has a custom equals that compares
+     * {@code List<ItemStack>} with {@code ItemStack.matches} and
+     * {@code Map<String, CompoundTag>} with NBT string equality, because the
+     * default record equals uses {@code ItemStack.equals} →
+     * {@code Object.equals} (reference) and {@code CompoundTag.equals} →
+     * {@code Tag.equals} (reference), which both fail for network-deserialised
+     * copies (issue #20). */
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<CelestweaveModuleContainer>>
             CELESTWEAVE_MODULES = DATA_COMPONENTS.registerComponentType(
                     "celestweave_modules",
                     builder -> builder
                             .persistent(CelestweaveModuleContainer.CODEC)
-                            .networkSynchronized(CelestweaveModuleContainer.STREAM_CODEC)
-                            .cacheEncoding());
+                            .networkSynchronized(CelestweaveModuleContainer.STREAM_CODEC));
 
     /**
      * Server-authoritative "modules are powered this tick" flag. Absent means powered (the common


### PR DESCRIPTION
# Summary

Close #20

# Cause

see issue

# Components
- CELESTWEAVE_MODULES/CelestweaveModuleContainer: record equals => List<ItemStack> => ItemStack.equals (reference) / CompoundTag.equals => Tag.equals (reference)

- CELESTWEAVE_STRUCTURAL_CORE/ItemStack: Objects.equals => ItemStack.equals (reference)

- CELESTWEAVE_ENERGY_BUFFER/Long: Value genuinely changes during charge/discharge, server ≠ client cache (correct diff detection, but shouldn't trigger equip sound)

# Other effects

- These two methods are widely used by Minecraft to determine whether two `ItemStack` instances are identical, `CELESTWEAVE_MODULES` or `CELESTWEAVE_STRUCTURAL_CORE` returns `false`. These issues do not only appear when clicking in the creative mode inventory. they subtly but continuously contaminate data synchronization between server and client.

- `detectEquipmentUpdates` compares `lastArmorItemStacks` against current armor every tick. Even if no sound is produced, these extraneous packets and events have performance implications (though negligible for a single player, the overhead accumulates on servers with multiple players).

- `CELESTWEAVE_MODULES` is registered with `.cacheEncoding()`. This feature caches the network encoding after the first serialization, and subsequent transmissions of the same container reuse it directly — however, if the container changes (modules installed/uninstalled, submodule data mutated), there is a window between the invalidation of the armor's cache and re-encoding, during which the client may receive a stale container encoding.

- `ArmorEnergyBuffer.write` calls `stack.set(CELESTWEAVE_ENERGY_BUFFER, value)` every tick. Even when the value hasn't changed

# Fixes

see issue also

# Verification

typically I would like to add some GameTests for it, but I found in this project there are only JUnit tests in src/test. However my tests have imports of ItemStack in minecraft package and making new tests files in the src/main/java package always seems impolite, so you can just download the snapshot file in the issue comment and have a in-game test.