### PR TITLE
fix(pigmee): drop null-player crafting callback

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/blockentity/PigmeeMolecularAssemblerBlockEntity.java
+++ b/src/main/java/com/moakiee/ae2lt/blockentity/PigmeeMolecularAssemblerBlockEntity.java
@@ -228,7 +228,6 @@ public final class PigmeeMolecularAssemblerBlockEntity extends AENetworkInvBlock
             return TickRateModulation.IDLE;
         }
 
-        output.onCraftedBy(level, null, 1);
         CraftingEvent.fireAutoCraftingEvent(level, activePattern, output, craftingGrid);
         var remainders = activePattern.getRemainingItems(craftingGrid);
 

--- a/src/test/java/com/moakiee/ae2lt/blockentity/PigmeeMolecularAssemblerCraftingContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/blockentity/PigmeeMolecularAssemblerCraftingContractTest.java
@@ -1,0 +1,47 @@
+package com.moakiee.ae2lt.blockentity;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class PigmeeMolecularAssemblerCraftingContractTest {
+    @Test
+    void automaticCraftingUsesTheAe2EventWithoutAPlayerItemCallback() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/blockentity/PigmeeMolecularAssemblerBlockEntity.java"));
+        String tickingRequest = methodBody(source,
+                "public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall)");
+
+        int assemble = tickingRequest.indexOf("activePattern.assemble(craftingGrid, level)");
+        int craftingEvent = tickingRequest.indexOf("CraftingEvent.fireAutoCraftingEvent(");
+        int remainders = tickingRequest.indexOf("activePattern.getRemainingItems(craftingGrid)");
+        int pushOutput = tickingRequest.indexOf("pushOutput(output.copy())");
+
+        assertTrue(assemble >= 0, "The active pattern must still produce the crafting output");
+        assertTrue(craftingEvent > assemble, "The AE2 auto-crafting event must follow assembly");
+        assertTrue(remainders > craftingEvent, "Remainders must be calculated after the crafting event");
+        assertTrue(pushOutput > remainders, "The crafted output must be pushed after remainder calculation");
+        assertFalse(tickingRequest.contains(".onCraftedBy("),
+                "Player-style crafting callbacks are invalid for this playerless assembler");
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        assertTrue(start >= 0, "Missing method: " + signature);
+        int bodyStart = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unterminated method: " + signature);
+    }
+}


### PR DESCRIPTION
## Summary
- Removes `output.onCraftedBy(level, null, 1)` from `PigmeeMolecularAssemblerBlockEntity#tickingRequest`, which crashed the server (NPE in `Player#awardStat`) whenever the crafted output item's `onCraftedBy` override touched the player.
- `CraftingEvent.fireAutoCraftingEvent` already covers this playerless assembler's auto-crafting needs, so the vanilla player-callback is not required here.
- Adds `PigmeeMolecularAssemblerCraftingContractTest` to lock in that the ticking path stays free of any `.onCraftedBy(` call.

## Test plan
- [x] Confirmed against a real crash report (`Ticking GridNode` -> `NullPointerException: ... Player.awardStat ... because "p_41680_" is null` at `PigmeeMolecularAssemblerBlockEntity.tickingRequest`).
- [x] `gradle test build` passes, including the new contract test.