### PR TITLE
fix: backport overload fuzzy pattern and tianshu mode sync from main

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/menu/TianshuPatternEncodingTermMenu.java
+++ b/src/main/java/com/moakiee/ae2lt/menu/TianshuPatternEncodingTermMenu.java
@@ -378,12 +378,20 @@ public class TianshuPatternEncodingTermMenu extends PatternEncodingTermMenu {
 
     @Override
     public void setMode(EncodingMode mode) {
-        if (mode != null) {
-            var extended = TianshuEncodingMode.fromAe2(mode);
-            if (isClientSide()) sendClientAction("setTianshuMode", extended);
-            else setTianshuModeServer(extended);
+        if (mode == null) {
+            super.setMode(null);
+            return;
         }
-        super.setMode(mode);
+        var extended = TianshuEncodingMode.fromAe2(mode);
+        if (isClientSide()) {
+            // AE2's recipe-viewer helper immediately follows this mode change with fake-slot
+            // updates and may encode in the same input event. Send its authoritative logic-mode
+            // action before the Tianshu mirror so the server never observes a stale native mode.
+            super.setMode(mode);
+            sendClientAction("setTianshuMode", extended);
+        } else {
+            alignNativeModeServer(extended, mode);
+        }
     }
 
     public boolean consumeTriggeredUpload() {
@@ -463,11 +471,25 @@ public class TianshuPatternEncodingTermMenu extends PatternEncodingTermMenu {
 
     private void setTianshuModeServer(TianshuEncodingMode mode) {
         if (!isServerSide() || mode == null) return;
+        if (mode.ae2Mode() != null) {
+            alignNativeModeServer(mode, mode.ae2Mode());
+        } else {
+            applyTianshuModeState(mode);
+        }
+        broadcastChanges();
+    }
+
+    private void alignNativeModeServer(TianshuEncodingMode mode, EncodingMode nativeMode) {
+        applyTianshuModeState(mode);
+        var logic = tianshuHost.getLogic();
+        if (logic.getMode() != nativeMode) logic.setMode(nativeMode);
+        if (getMode() != nativeMode) super.setMode(nativeMode);
+    }
+
+    private void applyTianshuModeState(TianshuEncodingMode mode) {
         if (tianshuMode != mode) resetProcessingEncodingType();
         tianshuMode = mode;
         tianshuHost.setTianshuEncodingMode(mode);
-        if (mode.ae2Mode() != null && getMode() != mode.ae2Mode()) super.setMode(mode.ae2Mode());
-        broadcastChanges();
     }
 
     public void multiplyProcessing(int factor) {

--- a/src/main/java/com/moakiee/ae2lt/overload/runtime/pattern/Ae2OverloadPatternDetails.java
+++ b/src/main/java/com/moakiee/ae2lt/overload/runtime/pattern/Ae2OverloadPatternDetails.java
@@ -1,7 +1,6 @@
 package com.moakiee.ae2lt.overload.runtime.pattern;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,34 +44,10 @@ public final class Ae2OverloadPatternDetails
         for (int slot = 0; slot < sourceInputs.length; slot++) {
             this.inputs[slot] = wrapInput(sourceInputs[slot], overloadDetails.inputMode(slot));
         }
-        this.outputs = wipeIdOnlyOutputs(sourceDetails.getOutputs(), overloadDetails);
-    }
-
-    /**
-     * An ID_ONLY slot is NBT-agnostic by contract, so the AE2-facing view erases the captured
-     * components ("仅id ⇒ 抹除NBT"): the declared key becomes the bare item. For an output slot this
-     * key is what indexes the pattern in the crafting service and what the CPU mirrors into its
-     * waiting list — the product must be requestable/consumable as the plain item, and must
-     * <em>not</em> satisfy strict demand for the originally captured variant (the machine may return
-     * any NBT). STRICT slots keep their exact captured keys. Output list positions are preserved:
-     * CPU-side code correlates {@code getOutputs()} entries with
-     * {@link OverloadPatternDetails.OutputSlot#slotIndex()} by index.
-     */
-    private static GenericStack[] wipeIdOnlyOutputs(GenericStack[] sourceOutputs,
-                                                    OverloadPatternDetails overloadDetails) {
-        var result = new GenericStack[sourceOutputs.length];
-        for (int slot = 0; slot < sourceOutputs.length; slot++) {
-            result[slot] = wipeIfIdOnly(sourceOutputs[slot], overloadDetails.outputMode(slot));
-        }
-        return result;
-    }
-
-    static GenericStack wipeIfIdOnly(GenericStack stack, MatchMode matchMode) {
-        if (!matchMode.ignoresComponents()
-                || !(stack.what() instanceof AEItemKey itemKey)) {
-            return stack;
-        }
-        return new GenericStack(itemKey.dropSecondary(), stack.amount());
+        // Match mode is metadata about the set of runtime keys. Keep the ordinary concrete output
+        // as AE2's catalog/waiting identity; the overload CPU side separately reconciles an actual
+        // same-id result against this concrete expected key.
+        this.outputs = sourceDetails.getOutputs().clone();
     }
 
     @Override
@@ -145,22 +120,12 @@ public final class Ae2OverloadPatternDetails
         private OverloadInput(IInput sourceInput, MatchMode matchMode) {
             this.sourceInput = sourceInput;
             this.matchMode = matchMode;
-            // Expose the component-wiped templates (see wipeIfIdOnly): the declared demand of an
-            // ID_ONLY slot is the bare item. Runtime acceptance is unchanged — isValid matches by
-            // item id, and CPU extraction resolves concrete variants through findFuzzyTemplates.
-            this.possibleInputs = wipePossibleInputs(sourceInput.getPossibleInputs(), matchMode);
+            // Preserve AE2's concrete discovery anchors. Runtime membership remains broader through
+            // isValid, while acceptsSameIdVariants supplies the separate same-id closure declaration.
+            this.possibleInputs = sourceInput.getPossibleInputs().clone();
             // Keep the ORIGINAL captured keys for getRemainingKey: the source input only understands
             // the templates it declared.
             this.itemKeys = collectItemKeys(sourceInput.getPossibleInputs());
-        }
-
-        private static GenericStack[] wipePossibleInputs(GenericStack[] source, MatchMode matchMode) {
-            var byKey = new LinkedHashMap<AEKey, GenericStack>(source.length);
-            for (var possible : source) {
-                var wiped = wipeIfIdOnly(possible, matchMode);
-                byKey.putIfAbsent(wiped.what(), wiped);
-            }
-            return byKey.values().toArray(new GenericStack[0]);
         }
 
         @Override

--- a/src/main/java/com/moakiee/ae2lt/overload/runtime/pattern/OverloadPatternDetails.java
+++ b/src/main/java/com/moakiee/ae2lt/overload/runtime/pattern/OverloadPatternDetails.java
@@ -104,7 +104,7 @@ public final class OverloadPatternDetails implements OverloadedProviderOnlyPatte
     private static InputSlot toInputSlot(ParsedPatternInput input, MatchMode matchMode) {
         return new InputSlot(
                 input.slotIndex(),
-                wipeIfIdOnly(normalizedCopy(input.stack()), matchMode),
+                normalizedCopy(input.stack()),
                 input.amountPerCraft(),
                 matchMode);
     }
@@ -112,7 +112,7 @@ public final class OverloadPatternDetails implements OverloadedProviderOnlyPatte
     private static OutputSlot toOutputSlot(ParsedPatternOutput output, MatchMode matchMode) {
         return new OutputSlot(
                 output.slotIndex(),
-                wipeIfIdOnly(normalizedCopy(output.stack()), matchMode),
+                normalizedCopy(output.stack()),
                 output.amountPerCraft(),
                 matchMode,
                 output.primaryOutput());
@@ -122,19 +122,6 @@ public final class OverloadPatternDetails implements OverloadedProviderOnlyPatte
         var copy = stack.copy();
         copy.setCount(1);
         return copy;
-    }
-
-    /**
-     * An ID_ONLY slot compares by item id only, so its template erases the captured components
-     * ("仅id ⇒ 抹除NBT"). This keeps every metadata consumer — tooltips, CPU pending-output
-     * registration, mirror accounting — consistent with the wiped AE2-facing keys exposed by
-     * {@code Ae2OverloadPatternDetails}.
-     */
-    static ItemStack wipeIfIdOnly(ItemStack stack, MatchMode matchMode) {
-        if (!matchMode.ignoresComponents()) {
-            return stack;
-        }
-        return new ItemStack(stack.getItem(), stack.getCount());
     }
 
     /**


### PR DESCRIPTION
## Summary

Backports two bug fixes from the main branch (1.21.x NeoForge) to the 1.20.1 Forge branch:

1. **fix(overload): preserve concrete fuzzy pattern keys** (upstream 4c0c29f6, 2026-08-28)  
   - ID_ONLY slots no longer wipe components from their declared keys
   - The concrete captured key remains as AE2's catalog/waiting identity
   - Runtime membership is handled through `isValid` and the overload CPU's same-id reconciliation
   - Fixes recipe discovery and demand matching errors

2. **fix(tianshu): synchronize recipe transfer mode before upload** (upstream 1c619af8, 2026-08-30)  
   - Client now sends `super.setMode(mode)` before `sendClientAction("setTianshuMode")`
   - Server aligns all three layers (Tianshu mode, logic.mode, menu.mode) atomically via `alignNativeModeServer`
   - Fixes race condition where the server observed stale native mode during recipe-viewer fill+encode

Both fixes were manually backported after verifying the affected files exist in 1.20.1 and the logic is identical.

## Test plan

- [x] Code review: changes match upstream diffs
- [ ] Build verification: deferred due to deobf cache unavailability (offline build failed)
- [ ] Runtime test:待上游 review 后补充

🤖 Generated with [Claude Code](https://claude.ai/claude-code)