### PR TITLE
fix: prevent Phase Lock and AE2CS wireless regressions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ mod_name=AE2 Lighting Tech
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=2.1.0-beta.2
+mod_version=2.1.0-beta.5
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -72,7 +72,7 @@ flux_networks_version_range=[7.2.1.15,8)
 glodium_file_id=5226922
 mekanism_version=1.20.1-10.4.16.80
 mekanism_version_range=[10.4.16,10.5)
-thunderbolt_version=2.0.0-beta.2
+thunderbolt_version=2.0.0-beta.4
 thunderbolt_artifact_id=thunderbolt-forge-1.20.1
 # Accept the compatible 2.0 beta/stable line instead of binding AE2LT to one exact Thunderbolt build.
 thunderbolt_version_range=[2.0.0-beta.2,2.1.0)

--- a/src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java
@@ -31,6 +31,10 @@ public final class PhaseFlightMovementGuard {
     private static final ThreadLocal<ServerPlayer> MAIN_THREAD_PAYLOAD_PLAYER = new ThreadLocal<>();
     private static final ThreadLocal<IdentityHashMap<Player, Integer>> MOVEMENT_POSITION_UPDATE_DEPTH =
             ThreadLocal.withInitial(IdentityHashMap::new);
+    private static final ThreadLocal<IdentityHashMap<Player, Integer>> ENVIRONMENT_MOVEMENT_DEPTH =
+            ThreadLocal.withInitial(IdentityHashMap::new);
+    private static final ThreadLocal<IdentityHashMap<Player, Integer>> VANILLA_TRAVEL_MOVEMENT_DEPTH =
+            ThreadLocal.withInitial(IdentityHashMap::new);
     private static final ThreadLocal<Player> MOVEMENT_PACKET_PLAYER = new ThreadLocal<>();
     private static final ThreadLocal<Player> CUSTOM_PAYLOAD_PLAYER = new ThreadLocal<>();
     private static final ThreadLocal<CommandSourceStack> COMMAND_SOURCE = new ThreadLocal<>();
@@ -104,6 +108,8 @@ public final class PhaseFlightMovementGuard {
             MAIN_THREAD_PAYLOAD_PLAYER.remove();
         }
         MOVEMENT_POSITION_UPDATE_DEPTH.get().remove(player);
+        ENVIRONMENT_MOVEMENT_DEPTH.get().remove(player);
+        VANILLA_TRAVEL_MOVEMENT_DEPTH.get().remove(player);
         if (MOVEMENT_PACKET_PLAYER.get() == player) {
             MOVEMENT_PACKET_PLAYER.remove();
         }
@@ -169,11 +175,16 @@ public final class PhaseFlightMovementGuard {
         if (player == null) {
             return false;
         }
-        if (SELF_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0) {
+        if (SELF_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0
+                || ENVIRONMENT_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0) {
+            return true;
+        }
+        if (consumeVanillaTravelMovement(player)) {
             return true;
         }
         return isCurrentMovementPacket(player);
     }
+
 
     /**
      * Teleport authorization is intentionally broader than force authorization. A serverbound
@@ -280,6 +291,70 @@ public final class PhaseFlightMovementGuard {
         } finally {
             endSelfMovement(player);
         }
+    }
+
+    /** Runs only the original fluid and bubble-column velocity updates for this player. */
+    public static void runAsEnvironmentMovement(Player player, Runnable movement) {
+        if (player == null) {
+            movement.run();
+            return;
+        }
+        var depths = ENVIRONMENT_MOVEMENT_DEPTH.get();
+        depths.merge(player, 1, Integer::sum);
+        try {
+            movement.run();
+        } finally {
+            int next = depths.getOrDefault(player, 0) - 1;
+            if (next <= 0) {
+                depths.remove(player);
+                if (depths.isEmpty()) {
+                    ENVIRONMENT_MOVEMENT_DEPTH.remove();
+                }
+            } else {
+                depths.put(player, next);
+            }
+        }
+    }
+
+
+    /** Authorizes one direct vanilla travel mutation without authorizing nested third-party code. */
+    public static void runAsVanillaTravelMovement(Player player, Runnable movement) {
+        if (player == null) {
+            movement.run();
+            return;
+        }
+        var permits = VANILLA_TRAVEL_MOVEMENT_DEPTH.get();
+        int previous = permits.getOrDefault(player, 0);
+        permits.put(player, previous + 1);
+        try {
+            movement.run();
+        } finally {
+            if (previous == 0) {
+                permits.remove(player);
+                if (permits.isEmpty()) {
+                    VANILLA_TRAVEL_MOVEMENT_DEPTH.remove();
+                }
+            } else {
+                permits.put(player, previous);
+            }
+        }
+    }
+
+    private static boolean consumeVanillaTravelMovement(Player player) {
+        var permits = VANILLA_TRAVEL_MOVEMENT_DEPTH.get();
+        int remaining = permits.getOrDefault(player, 0);
+        if (remaining <= 0) {
+            return false;
+        }
+        if (remaining == 1) {
+            permits.remove(player);
+            if (permits.isEmpty()) {
+                VANILLA_TRAVEL_MOVEMENT_DEPTH.remove();
+            }
+        } else {
+            permits.put(player, remaining - 1);
+        }
+        return true;
     }
 
     /** Marks only the nested position writes performed by {@code Entity.move}. */

--- a/src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java
@@ -105,7 +105,13 @@ public final class PhaseLockSubmodule extends AbstractCelestweaveArmorSubmodule 
             return false;
         }
         var options = getOptions(armor);
-        options.put(key, value instanceof ByteTag byteTag ? byteTag : ByteTag.valueOf(true));
+        if (value == null) {
+            options.remove(key);
+        } else if (value instanceof ByteTag byteTag) {
+            options.put(key, ByteTag.valueOf(byteTag.getAsByte() != 0));
+        } else {
+            options.put(key, ByteTag.valueOf(defaultValue(key)));
+        }
         setOptions(armor, options);
         return true;
     }
@@ -191,7 +197,19 @@ public final class PhaseLockSubmodule extends AbstractCelestweaveArmorSubmodule 
 
     private static boolean booleanOption(ItemStack armor, String key) {
         var options = INSTANCE.getOptions(armor);
-        return !options.contains(key, Tag.TAG_BYTE) || options.getBoolean(key);
+        return options.contains(key, Tag.TAG_BYTE)
+                ? options.getBoolean(key)
+                : defaultValue(key);
+    }
+
+    private static boolean defaultValue(String key) {
+        return switch (key) {
+            case ARMOR_LOCK_CONFIG_KEY,
+                    FLIGHT_LOCK_CONFIG_KEY,
+                    BLOCK_EXTERNAL_FORCES_CONFIG_KEY,
+                    BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> false;
+            default -> false;
+        };
     }
 
     private static void updateMovementProtection(Player player, ItemStack armor) {

--- a/src/main/java/com/moakiee/ae2lt/celestweave/phase/PhaseLockProjectionSynchronizer.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/phase/PhaseLockProjectionSynchronizer.java
@@ -207,6 +207,10 @@ final class PhaseLockProjectionSynchronizer {
             ItemStack projection,
             ProjectionCurses projectionCurses) {
         Map<Enchantment, Integer> enchantments = enchantments(projection);
+        if (enchantments.getOrDefault(projectionCurses.binding(), 0) == 1
+                && enchantments.getOrDefault(projectionCurses.vanishing(), 0) == 1) {
+            return;
+        }
         enchantments.put(projectionCurses.binding(), 1);
         enchantments.put(projectionCurses.vanishing(), 1);
         setEnchantments(projection, enchantments);

--- a/src/main/java/com/moakiee/ae2lt/client/LightningKeyClientInit.java
+++ b/src/main/java/com/moakiee/ae2lt/client/LightningKeyClientInit.java
@@ -33,6 +33,7 @@ public final class LightningKeyClientInit {
     public static void onClientSetup(FMLClientSetupEvent event) {
         event.enqueueWork(() -> {
             RailgunClientBootstrap.install();
+            ResearchNoteClientBootstrap.install();
             ShieldHitFeedbackClientBootstrap.install();
             if (ModList.get().isLoaded("curios")) {
                 PigmeeCuriosClientBridge.registerRenderers();

--- a/src/main/java/com/moakiee/ae2lt/client/ResearchNoteClientBootstrap.java
+++ b/src/main/java/com/moakiee/ae2lt/client/ResearchNoteClientBootstrap.java
@@ -1,0 +1,35 @@
+package com.moakiee.ae2lt.client;
+
+import com.moakiee.ae2lt.item.ResearchNoteItem;
+import com.moakiee.ae2lt.network.ResearchNoteClientBridge;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.BookViewScreen;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.WrittenBookItem;
+
+public final class ResearchNoteClientBootstrap {
+    private static boolean installed;
+
+    private ResearchNoteClientBootstrap() {
+    }
+
+    public static void install() {
+        if (installed) {
+            return;
+        }
+        ResearchNoteClientBridge.install(new ResearchNoteClientBridge.Hooks() {
+            @Override
+            public void open(ItemStack book) {
+                if (!(book.getItem() instanceof ResearchNoteItem)
+                        || !ResearchNoteItem.isGenerated(book)
+                        || !WrittenBookItem.makeSureTagIsValid(book.getTag())) {
+                    return;
+                }
+                Minecraft.getInstance().setScreen(
+                        new BookViewScreen(new BookViewScreen.WrittenBookAccess(book)));
+            }
+        });
+        installed = true;
+    }
+}

--- a/src/main/java/com/moakiee/ae2lt/grid/wirelesslink/WirelessLinkOps.java
+++ b/src/main/java/com/moakiee/ae2lt/grid/wirelesslink/WirelessLinkOps.java
@@ -39,6 +39,15 @@ public final class WirelessLinkOps {
                 && connection.getOtherSide(node) == other;
     }
 
+    public static @Nullable IGridConnection findConnection(IGridNode node, IGridNode other) {
+        for (var connection : node.getConnections()) {
+            if (connection.getOtherSide(node) == other && hasLiveConnection(connection, other)) {
+                return connection;
+            }
+        }
+        return null;
+    }
+
     public static void destroy(@Nullable IGridConnection connection, @Nullable IGridNode node) {
         WIRELESS_BRIDGES.remove(connection);
         if (hasLiveConnection(connection, node) && !connection.isInWorld()) {
@@ -58,18 +67,37 @@ public final class WirelessLinkOps {
         WIRELESS_BRIDGES.clear();
     }
 
-    public static IGridConnection createVirtualConnection(IGridNode targetNode, IGridNode transmitterNode) {
-        for (var connection : targetNode.getConnections()) {
-            if (connection.getOtherSide(targetNode) == transmitterNode) {
-                if (!connection.isInWorld()) {
-                    trackWirelessBridge(connection);
-                    return connection;
-                }
-                throw new IllegalStateException("A physical connection already exists between the target and transmitter.");
-            }
+    public static synchronized IGridConnection createVirtualConnection(IGridNode targetNode, IGridNode transmitterNode) {
+        var existing = findConnection(targetNode, transmitterNode);
+        if (existing != null) {
+            return reuseVirtualConnection(existing);
         }
-        var connection = GridConnection.create(targetNode, transmitterNode, null);
+
+        try {
+            var connection = GridConnection.create(targetNode, transmitterNode, null);
+            trackWirelessBridge(connection);
+            return connection;
+        } catch (IllegalStateException duplicateCandidate) {
+            existing = findConnection(targetNode, transmitterNode);
+            if (isDuplicateConnectionFailure(duplicateCandidate)
+                    && existing != null
+                    && !existing.isInWorld()) {
+                return reuseVirtualConnection(existing);
+            }
+            throw duplicateCandidate;
+        }
+    }
+
+    private static IGridConnection reuseVirtualConnection(IGridConnection connection) {
+        if (connection.isInWorld()) {
+            throw new IllegalStateException("A physical connection already exists between the target and transmitter.");
+        }
         trackWirelessBridge(connection);
         return connection;
+    }
+
+    private static boolean isDuplicateConnectionFailure(IllegalStateException exception) {
+        var message = exception.getMessage();
+        return message != null && message.contains("already exists");
     }
 }

--- a/src/main/java/com/moakiee/ae2lt/item/ResearchNoteItem.java
+++ b/src/main/java/com/moakiee/ae2lt/item/ResearchNoteItem.java
@@ -7,13 +7,14 @@ import org.jetbrains.annotations.Nullable;
 
 import com.moakiee.ae2lt.logic.research.ResearchNoteData;
 import com.moakiee.ae2lt.logic.research.ResearchNoteGenerator;
+import com.moakiee.ae2lt.network.OpenResearchNotePacket;
+import com.moakiee.ae2lt.network.PacketSender;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.protocol.game.ClientboundOpenBookPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.Stats;
@@ -69,13 +70,8 @@ public class ResearchNoteItem extends AE2LTItem {
         // 即便被强行堆,也不在此处处理)。
         applyGeneratedState(heldStack, data);
 
-        // ServerPlayer#openItemGui 只认 vanilla Items.WRITTEN_BOOK，直接拿我们的自定义
-        // 物品去走那条分支会提前 return。所以这里手动走一遍官方链路：先 resolve 书页
-        // 里的动态组件（实体选择器之类），再把 ClientboundOpenBookPacket 直接发给客户端。
-        // 客户端随后会基于当前手持物上的 written-book NBT 打开阅读界面。
         if (player instanceof ServerPlayer serverPlayer) {
-            WrittenBookItem.resolveBookComponents(heldStack, serverPlayer.createCommandSourceStack(), serverPlayer);
-            serverPlayer.connection.send(new ClientboundOpenBookPacket(hand));
+            PacketSender.sendToPlayer(serverPlayer, new OpenResearchNotePacket(heldStack.copy()));
         }
         player.awardStat(Stats.ITEM_USED.get(this));
         return InteractionResultHolder.sidedSuccess(heldStack, false);

--- a/src/main/java/com/moakiee/ae2lt/mixin/AE2LTMixinConfigPlugin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/AE2LTMixinConfigPlugin.java
@@ -14,7 +14,8 @@ import net.minecraftforge.fml.loading.LoadingModList;
 public final class AE2LTMixinConfigPlugin implements IMixinConfigPlugin {
     private static final Map<String, String> REQUIRED_MODS = Map.of(
             "AdvCraftingCpuAccessor", "advanced_ae",
-            "AdvCraftingCpuLogicMixin", "advanced_ae");
+            "AdvCraftingCpuLogicMixin", "advanced_ae",
+            "BroadcastFrequencyBandMixin", "ae2cs");
 
     @Override
     public void onLoad(String mixinPackage) {

--- a/src/main/java/com/moakiee/ae2lt/mixin/BroadcastFrequencyBandMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/BroadcastFrequencyBandMixin.java
@@ -1,0 +1,38 @@
+package com.moakiee.ae2lt.mixin;
+
+import appeng.api.networking.GridHelper;
+import appeng.api.networking.IGridConnection;
+import appeng.api.networking.IGridNode;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.moakiee.ae2lt.grid.wirelesslink.WirelessLinkOps;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Keeps AE2CS receiver recalculation from creating a duplicate logical link after its old
+ * connection has already been destroyed by another synchronous recalculation path.
+ */
+@Pseudo
+@Mixin(
+        targets = "io.github.lounode.ae2cs.api.linker.broadcast.BroadcastFrequencyBand",
+        remap = false)
+public abstract class BroadcastFrequencyBandMixin {
+    @WrapOperation(
+            method = "applyReceiver(Lnet/minecraft/core/GlobalPos;Lappeng/api/networking/IGridNode;Lio/github/lounode/ae2cs/api/CustomChannelProviderHost;I)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/GridHelper;createConnection(Lappeng/api/networking/IGridNode;Lappeng/api/networking/IGridNode;)Lappeng/api/networking/IGridConnection;"),
+            remap = false)
+    private IGridConnection ae2lt$reuseExistingReceiverConnection(
+            IGridNode controllerNode,
+            IGridNode receiverNode,
+            Operation<IGridConnection> original) {
+        var existing = WirelessLinkOps.findConnection(controllerNode, receiverNode);
+        if (existing != null && !existing.isInWorld()) {
+            return existing;
+        }
+        return original.call(controllerNode, receiverNode);
+    }
+}

--- a/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
@@ -1,21 +1,29 @@
 package com.moakiee.ae2lt.mixin;
 
+import java.util.function.BiConsumer;
+
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import org.apache.commons.lang3.tuple.MutableTriple;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 
-import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
+import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.fluids.FluidType;
+
 import com.moakiee.ae2lt.celestweave.PhaseFlightControlRules;
+import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
 import com.moakiee.ae2lt.celestweave.PhaseFlightPlayerState;
 import com.moakiee.ae2lt.celestweave.PhaseWingFlight;
 
@@ -31,6 +39,57 @@ public abstract class EntityPhaseMovementMixin {
                         player.isShiftKeyDown())) {
             cir.setReturnValue(true);
         }
+    }
+
+    @WrapOperation(
+            method = {
+                "updateFluidHeightAndDoFluidPushing()V",
+                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"
+            },
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V",
+                    remap = false),
+            remap = false)
+    private void ae2lt$authorizeVanillaFluidPushes(
+            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> fluidData,
+            BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>> consumer,
+            Operation<Void> original) {
+        Player player = (Object) this instanceof Player currentPlayer ? currentPlayer : null;
+        original.call(fluidData, (BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>>)
+                (fluidType, data) -> {
+                    if (player != null
+                            && (fluidType == ForgeMod.WATER_TYPE.get()
+                                    || fluidType == ForgeMod.LAVA_TYPE.get())) {
+                        PhaseFlightMovementGuard.runAsEnvironmentMovement(
+                                player,
+                                () -> consumer.accept(fluidType, data));
+                    } else {
+                        consumer.accept(fluidType, data);
+                    }
+                });
+    }
+
+    @WrapMethod(method = "onAboveBubbleCol(Z)V")
+    private void ae2lt$authorizeAboveBubbleMovement(boolean dragDown, Operation<Void> original) {
+        if ((Object) this instanceof Player player) {
+            PhaseFlightMovementGuard.runAsEnvironmentMovement(
+                    player,
+                    () -> original.call(dragDown));
+            return;
+        }
+        original.call(dragDown);
+    }
+
+    @WrapMethod(method = "onInsideBubbleColumn(Z)V")
+    private void ae2lt$authorizeInsideBubbleMovement(boolean dragDown, Operation<Void> original) {
+        if ((Object) this instanceof Player player) {
+            PhaseFlightMovementGuard.runAsEnvironmentMovement(
+                    player,
+                    () -> original.call(dragDown));
+            return;
+        }
+        original.call(dragDown);
     }
 
     @WrapMethod(method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V")

--- a/src/main/java/com/moakiee/ae2lt/mixin/LivingEntityPhaseJumpMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/LivingEntityPhaseJumpMixin.java
@@ -7,17 +7,54 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
 
 import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
 
-/**
- * Authorizes only vanilla's two ground-jump impulses, without opening the rest of aiStep.
- * <p>1.20.1 note: both impulses (main + sprint) go through {@code setDeltaMovement(DDD)};
- * the {@code addDeltaMovement(Vec3)} sprint path of newer versions does not exist here.</p>
- */
+/** Authorizes only direct vanilla travel and jump mutations. */
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityPhaseJumpMixin {
+    @WrapOperation(
+            method = "travel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/LivingEntity;move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V"))
+    private void ae2lt$authorizeVanillaTravelMove(
+            LivingEntity entity,
+            MoverType moverType,
+            Vec3 movement,
+            Operation<Void> original) {
+        runAsVanillaTravelMovement(entity, () -> original.call(entity, moverType, movement));
+    }
+
+    @WrapOperation(
+            method = "travel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/LivingEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"))
+    private void ae2lt$authorizeVanillaTravelVelocity(
+            LivingEntity entity,
+            Vec3 movement,
+            Operation<Void> original) {
+        runAsVanillaTravelMovement(entity, () -> original.call(entity, movement));
+    }
+
+    @WrapOperation(
+            method = "travel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/LivingEntity;setDeltaMovement(DDD)V"))
+    private void ae2lt$authorizeVanillaTravelVelocityComponents(
+            LivingEntity entity,
+            double x,
+            double y,
+            double z,
+            Operation<Void> original) {
+        runAsVanillaTravelMovement(entity, () -> original.call(entity, x, y, z));
+    }
+
     @WrapOperation(
             method = "jumpFromGround",
             at = @At(
@@ -36,5 +73,13 @@ public abstract class LivingEntityPhaseJumpMixin {
             return;
         }
         original.call(entity, x, y, z);
+    }
+
+    private static void runAsVanillaTravelMovement(LivingEntity entity, Runnable movement) {
+        if (entity instanceof Player player) {
+            PhaseFlightMovementGuard.runAsVanillaTravelMovement(player, movement);
+        } else {
+            movement.run();
+        }
     }
 }

--- a/src/main/java/com/moakiee/ae2lt/mixin/PlayerPhaseFlightMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/PlayerPhaseFlightMixin.java
@@ -1,6 +1,8 @@
 package com.moakiee.ae2lt.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Final;
@@ -146,14 +148,34 @@ public abstract class PlayerPhaseFlightMixin implements PhaseFlightPlayerState.A
         ci.cancel();
     }
 
-    @Inject(method = "travel", at = @At("HEAD"))
-    private void ae2lt$beginPlayerAuthorizedTravel(Vec3 travelVector, CallbackInfo ci) {
-        PhaseFlightMovementGuard.beginSelfMovement((Player) (Object) this);
+    @WrapOperation(
+            method = "travel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/player/Player;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"))
+    private void ae2lt$authorizePlayerTravelVelocity(
+            Player player,
+            Vec3 movement,
+            Operation<Void> original) {
+        PhaseFlightMovementGuard.runAsVanillaTravelMovement(
+                player,
+                () -> original.call(player, movement));
     }
 
-    @Inject(method = "travel", at = @At("RETURN"))
-    private void ae2lt$endPlayerAuthorizedTravel(Vec3 travelVector, CallbackInfo ci) {
-        PhaseFlightMovementGuard.endSelfMovement((Player) (Object) this);
+    @WrapOperation(
+            method = "travel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/player/Player;setDeltaMovement(DDD)V"))
+    private void ae2lt$authorizePlayerTravelVelocityComponents(
+            Player player,
+            double x,
+            double y,
+            double z,
+            Operation<Void> original) {
+        PhaseFlightMovementGuard.runAsVanillaTravelMovement(
+                player,
+                () -> original.call(player, x, y, z));
     }
 
     @Inject(

--- a/src/main/java/com/moakiee/ae2lt/network/NetworkInit.java
+++ b/src/main/java/com/moakiee/ae2lt/network/NetworkInit.java
@@ -30,8 +30,8 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import java.util.Optional;
 
 public final class NetworkInit {
-    // Version 2 adds paged closed-loop result request/response messages.
-    private static final String PROTOCOL_VERSION = "2";
+    // Version 3 adds the research-note screen message.
+    private static final String PROTOCOL_VERSION = "3";
     public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
             id("main"),
             () -> PROTOCOL_VERSION,
@@ -360,6 +360,14 @@ public final class NetworkInit {
                 (pkt, buf) -> pkt.write(buf),
                 ClosedLoopResultPagePacket::decode,
                 ClosedLoopResultPagePacket::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+
+        CHANNEL.registerMessage(
+                nextPacketId++,
+                OpenResearchNotePacket.class,
+                (pkt, buf) -> pkt.write(buf),
+                OpenResearchNotePacket::decode,
+                OpenResearchNotePacket::handle,
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
     }
 

--- a/src/main/java/com/moakiee/ae2lt/network/OpenResearchNotePacket.java
+++ b/src/main/java/com/moakiee/ae2lt/network/OpenResearchNotePacket.java
@@ -1,0 +1,23 @@
+package com.moakiee.ae2lt.network;
+
+import java.util.function.Supplier;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.network.NetworkEvent;
+
+public record OpenResearchNotePacket(ItemStack book) {
+    public void write(FriendlyByteBuf buf) {
+        buf.writeItem(book);
+    }
+
+    public static OpenResearchNotePacket decode(FriendlyByteBuf buf) {
+        return new OpenResearchNotePacket(buf.readItem());
+    }
+
+    public static void handle(OpenResearchNotePacket packet, Supplier<NetworkEvent.Context> context) {
+        NetworkEvent.Context ctx = context.get();
+        ctx.enqueueWork(() -> ResearchNoteClientBridge.open(packet.book()));
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/moakiee/ae2lt/network/ResearchNoteClientBridge.java
+++ b/src/main/java/com/moakiee/ae2lt/network/ResearchNoteClientBridge.java
@@ -1,0 +1,28 @@
+package com.moakiee.ae2lt.network;
+
+import java.util.Objects;
+
+import net.minecraft.world.item.ItemStack;
+
+public final class ResearchNoteClientBridge {
+    private static Hooks hooks = Hooks.NOOP;
+
+    private ResearchNoteClientBridge() {
+    }
+
+    public static void install(Hooks hooks) {
+        ResearchNoteClientBridge.hooks = Objects.requireNonNull(hooks);
+    }
+
+    public static void open(ItemStack book) {
+        hooks.open(book);
+    }
+
+    public interface Hooks {
+        Hooks NOOP = new Hooks() {
+        };
+
+        default void open(ItemStack book) {
+        }
+    }
+}

--- a/src/main/resources/ae2lt.mixins.json
+++ b/src/main/resources/ae2lt.mixins.json
@@ -41,7 +41,8 @@
     "EjectGhostBEMixin",
     "MenuTypeBuilderAccessor",
     "AEBaseMenuAccessor",
-    "ShulkerBulletMixin"
+    "ShulkerBulletMixin",
+    "BroadcastFrequencyBandMixin"
   ],
   "client": [
     "client.CableBusRenderStateMixin",

--- a/src/test/java/com/moakiee/ae2lt/assets/GuideMetadataParityTest.java
+++ b/src/test/java/com/moakiee/ae2lt/assets/GuideMetadataParityTest.java
@@ -23,7 +23,11 @@ class GuideMetadataParityTest {
             "src", "main", "resources", "assets", "ae2lt", "ae2guide");
     private static final Path CHINESE_GUIDE = GUIDE.resolve("_zh_cn");
     private static final Pattern FRONTMATTER = Pattern.compile("(?s)^---\\s*\\R(.*?)\\R---");
-    private static final Pattern ITEM_ID = Pattern.compile("(?m)^\\s*-\\s+(ae2lt:[a-z0-9_./-]+)\\s*$");
+    private static final Pattern ITEM_IDS = Pattern.compile(
+            "(?m)^item_ids:[ \\t]*\\R((?:[ \\t]*-[ \\t]+[^\\r\\n]+\\R?)*)");
+    private static final Pattern ITEM_IDS_DECLARATION = Pattern.compile("(?m)^item_ids[ \\t]*:");
+    private static final Pattern ITEM_ID = Pattern.compile(
+            "\\s*-\\s+([a-z0-9_.-]+:[a-z0-9_./-]+)\\s*");
     private static final Pattern ITEM_LINK = Pattern.compile(
             "<ItemLink\\s+[^>]*id=\\\"(ae2lt:[a-z0-9_./-]+)\\\"");
     private static final Pattern NAMESPACED_HELP_TOPIC = Pattern.compile(
@@ -57,6 +61,22 @@ class GuideMetadataParityTest {
                 .filter(path -> !path.startsWith(CHINESE_GUIDE))
                 .toList());
         assertItemLinkOwners("zh_cn", guidePages(CHINESE_GUIDE));
+    }
+
+    @Test
+    void globalItemIndexOnlyClaimsAe2ltItems() throws IOException {
+        List<String> invalid = new ArrayList<>();
+
+        for (Path page : guidePages(GUIDE)) {
+            for (String itemId : itemIds(page)) {
+                if (!itemId.startsWith("ae2lt:")) {
+                    invalid.add(GUIDE.relativize(page) + ": " + itemId);
+                }
+            }
+        }
+
+        assertEquals(List.of(), invalid,
+                "Foreign items belong in ItemLink content, not GuideME item_ids ownership");
     }
 
     @Test
@@ -114,10 +134,30 @@ class GuideMetadataParityTest {
             return Set.of();
         }
 
+        String metadata = frontmatter.group(1);
+        Matcher itemIdsBlock = ITEM_IDS.matcher(metadata);
+        if (!itemIdsBlock.find()) {
+            if (ITEM_IDS_DECLARATION.matcher(metadata).find()) {
+                throw new AssertionError(page + " must use a non-empty item_ids block list");
+            }
+            return Set.of();
+        }
+
         Set<String> result = new HashSet<>();
-        Matcher itemIds = ITEM_ID.matcher(frontmatter.group(1));
-        while (itemIds.find()) {
-            result.add(itemIds.group(1));
+        for (String line : itemIdsBlock.group(1).split("\\R")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            Matcher itemId = ITEM_ID.matcher(line);
+            if (!itemId.matches()) {
+                throw new AssertionError(page + " has a non-canonical item_ids entry: " + line.trim());
+            }
+            if (!result.add(itemId.group(1))) {
+                throw new AssertionError(page + " repeats item_ids entry " + itemId.group(1));
+            }
+        }
+        if (result.isEmpty()) {
+            throw new AssertionError(page + " has an empty item_ids block");
         }
         return result;
     }

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
@@ -1,0 +1,82 @@
+package com.moakiee.ae2lt.celestweave;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+final class PhaseEnvironmentMovementSourceContractTest {
+    @Test
+    void forceScopesArePlayerBoundFinallySafeAndSeparatedFromTeleport() throws Exception {
+        String guard = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java"));
+
+        assertTrue(guard.contains("ENVIRONMENT_MOVEMENT_DEPTH"));
+        assertTrue(guard.contains("runAsEnvironmentMovement(Player player, Runnable movement)"));
+        assertTrue(guard.contains("VANILLA_TRAVEL_MOVEMENT_DEPTH"));
+        assertTrue(guard.contains("runAsVanillaTravelMovement(Player player, Runnable movement)"));
+        assertTrue(guard.contains("consumeVanillaTravelMovement(player)"));
+        assertTrue(guard.contains("try {"));
+        assertTrue(guard.contains("finally {"));
+        assertFalse(guard.contains("isInWater() || isInLava()"));
+
+        String teleportAuthorization = methodBody(
+                guard,
+                "public static boolean isSelfTeleportAuthorized",
+                "private static boolean isPrivilegedCommandExecution");
+        assertFalse(teleportAuthorization.contains("ENVIRONMENT_MOVEMENT_DEPTH"));
+        assertFalse(teleportAuthorization.contains("VANILLA_TRAVEL_MOVEMENT_DEPTH"));
+    }
+
+    @Test
+    void vanillaFluidAndBubbleSourcesUseNarrowEnvironmentScopes() throws Exception {
+        String mixin = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java"));
+
+        assertTrue(mixin.contains("updateFluidHeightAndDoFluidPushing()V"));
+        assertTrue(mixin.contains(
+                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"));
+        assertTrue(mixin.contains("Object2ObjectMap;forEach"));
+        assertFalse(mixin.contains("lambda$updateFluidHeightAndDoFluidPushing$"));
+        assertTrue(mixin.contains("fluidType == ForgeMod.WATER_TYPE.get()"));
+        assertTrue(mixin.contains("fluidType == ForgeMod.LAVA_TYPE.get()"));
+        assertTrue(mixin.contains("onAboveBubbleCol(Z)V"));
+        assertTrue(mixin.contains("onInsideBubbleColumn(Z)V"));
+        assertTrue(mixin.contains("PhaseFlightMovementGuard.runAsEnvironmentMovement"));
+        assertFalse(mixin.contains("isInWater()"));
+        assertFalse(mixin.contains("isInLava()"));
+        assertFalse(mixin.contains("isFreezing()"));
+    }
+
+    @Test
+    void vanillaTravelAuthorizesOnlyItsDirectMutationCalls() throws Exception {
+        String livingMixin = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/mixin/LivingEntityPhaseJumpMixin.java"));
+        String playerMixin = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/mixin/PlayerPhaseFlightMixin.java"));
+
+        assertTrue(livingMixin.contains("method = \"travel\""));
+        assertTrue(livingMixin.contains("LivingEntity;move("));
+        assertTrue(livingMixin.contains("LivingEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"));
+        assertTrue(livingMixin.contains("LivingEntity;setDeltaMovement(DDD)V"));
+        assertTrue(livingMixin.contains("runAsVanillaTravelMovement(entity"));
+        assertFalse(livingMixin.contains("moveInFluid"));
+
+        assertTrue(playerMixin.contains("method = \"travel\""));
+        assertTrue(playerMixin.contains("Player;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"));
+        assertTrue(playerMixin.contains("Player;setDeltaMovement(DDD)V"));
+        assertTrue(playerMixin.contains("runAsVanillaTravelMovement("));
+        assertFalse(playerMixin.contains("@WrapMethod(method = \"travel\")"));
+        assertFalse(playerMixin.contains("runAsSelfMovement("));
+    }
+
+    private static String methodBody(String source, String start, String end) {
+        int startIndex = source.indexOf(start);
+        int endIndex = source.indexOf(end, startIndex);
+        assertTrue(startIndex >= 0 && endIndex > startIndex);
+        return source.substring(startIndex, endIndex);
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseLockSubmoduleSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseLockSubmoduleSourceContractTest.java
@@ -1,0 +1,60 @@
+package com.moakiee.ae2lt.celestweave;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+final class PhaseLockSubmoduleSourceContractTest {
+    private static final Path SOURCE = Path.of(
+            "src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java");
+
+    @Test
+    void everyFeatureHasAnExplicitIndependentDefault() throws Exception {
+        String source = Files.readString(SOURCE);
+
+        int defaults = source.indexOf("private static boolean defaultValue(String key)");
+        int nextMethod = source.indexOf("private static void", defaults);
+        String defaultBody = source.substring(defaults, nextMethod).replaceAll("\\s+", " ");
+        assertTrue(defaultBody.contains(
+                "case ARMOR_LOCK_CONFIG_KEY, FLIGHT_LOCK_CONFIG_KEY, "
+                        + "BLOCK_EXTERNAL_FORCES_CONFIG_KEY, "
+                        + "BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> false;"));
+        assertFalse(defaultBody.contains("-> true"));
+        assertFalse(source.contains("!options.contains(key, Tag.TAG_BYTE) || options.getBoolean(key)"));
+        assertTrue(source.contains("options.contains(key, Tag.TAG_BYTE)"));
+    }
+
+    @Test
+    void configWritesAndResetsUseTheSameBooleanSemantics() throws Exception {
+        String source = Files.readString(SOURCE);
+
+        assertTrue(source.contains("if (value == null)"));
+        assertTrue(source.contains("options.remove(key)"));
+        assertTrue(source.contains("value instanceof ByteTag byteTag"));
+        assertTrue(source.contains("ByteTag.valueOf(byteTag.getAsByte() != 0)"));
+        assertTrue(source.contains("ByteTag.valueOf(defaultValue(key))"));
+        int update = source.indexOf("private static void updateMovementProtection");
+        int nextMethod = source.indexOf("private static void updateFlightLock", update);
+        String updateBody = source.substring(update, nextMethod);
+        assertTrue(updateBody.contains("PhaseFlightMovementGuard.updatePhaseLockProtection("));
+        assertTrue(updateBody.contains("blocksExternalForces(armor)"));
+        assertTrue(updateBody.contains("blocksExternalTeleports(armor)"));
+    }
+
+    @Test
+    void moduleLevelActivationDoesNotTurnFeatureFlagsOn() throws Exception {
+        String source = Files.readString(SOURCE);
+
+        int activation = source.indexOf("public void onActivated");
+        int deactivation = source.indexOf("public void onDeactivated", activation);
+        String body = source.substring(activation, deactivation);
+        assertTrue(body.contains("updateMovementProtection(player, armor)"));
+        assertTrue(body.contains("updateFlightLock(player)"));
+        assertFalse(body.contains("setConfig("));
+        assertFalse(body.contains("ByteTag.valueOf(true)"));
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/celestweave/phase/PhaseLockProjectionNbtSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/phase/PhaseLockProjectionNbtSourceContractTest.java
@@ -19,4 +19,26 @@ class PhaseLockProjectionNbtSourceContractTest {
         assertTrue(synchronizer.contains("normalizedEnchantments.isEmpty()"));
         assertTrue(synchronizer.contains("entries.sort(Comparator.comparing("));
     }
+
+    @Test
+    void unchangedProjectionDoesNotReplaceMirroredComponentsEveryTick() throws Exception {
+        String synchronizer = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/celestweave/phase/PhaseLockProjectionSynchronizer.java"));
+
+        int noneBranch = synchronizer.indexOf(
+                "if (direction == PhaseLockProjectionSyncRules.Direction.NONE)");
+        int branchReturn = synchronizer.indexOf("return;", noneBranch);
+        int firstReplacement = synchronizer.indexOf("replaceMirroredComponents(", noneBranch);
+        assertTrue(noneBranch >= 0);
+        assertTrue(branchReturn > noneBranch);
+        assertTrue(firstReplacement > branchReturn);
+
+        int curseMethod = synchronizer.indexOf("private static void ensureProjectionCurses");
+        int setEnchantments = synchronizer.indexOf(
+                "setEnchantments(projection, enchantments)", curseMethod);
+        String curseBody = synchronizer.substring(curseMethod, setEnchantments);
+        assertTrue(curseBody.contains("getOrDefault(projectionCurses.binding(), 0) == 1"));
+        assertTrue(curseBody.contains("getOrDefault(projectionCurses.vanishing(), 0) == 1"));
+        assertTrue(curseBody.contains("return;"));
+    }
 }

--- a/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/Ae2csCompatibilitySourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/Ae2csCompatibilitySourceContractTest.java
@@ -1,0 +1,40 @@
+package com.moakiee.ae2lt.grid.wirelesslink;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class Ae2csCompatibilitySourceContractTest {
+    private static final Path MAIN_JAVA = Path.of("src/main/java");
+
+    @Test
+    void targetsOnlyAe2csReceiverRebuildAndUsesEndpointIdentity() throws Exception {
+        String mixin = Files.readString(MAIN_JAVA.resolve(
+                "com/moakiee/ae2lt/mixin/BroadcastFrequencyBandMixin.java"));
+        String config = Files.readString(Path.of("src/main/resources/ae2lt.mixins.json"));
+        String plugin = Files.readString(MAIN_JAVA.resolve(
+                "com/moakiee/ae2lt/mixin/AE2LTMixinConfigPlugin.java"));
+
+        assertTrue(mixin.contains(
+                "io.github.lounode.ae2cs.api.linker.broadcast.BroadcastFrequencyBand"));
+        assertTrue(mixin.contains(
+                "applyReceiver(Lnet/minecraft/core/GlobalPos;Lappeng/api/networking/IGridNode;Lio/github/lounode/ae2cs/api/CustomChannelProviderHost;I)V"));
+        assertTrue(mixin.contains("WirelessLinkOps.findConnection(controllerNode, receiverNode)"));
+        assertTrue(mixin.contains("!existing.isInWorld()"));
+        assertTrue(mixin.contains("return original.call(controllerNode, receiverNode);"));
+        assertTrue(config.contains("BroadcastFrequencyBandMixin"));
+        assertTrue(plugin.contains("\"BroadcastFrequencyBandMixin\", \"ae2cs\""));
+    }
+
+    @Test
+    void doesNotSwallowPhysicalOrUnrelatedConnectionFailures() throws Exception {
+        String mixin = Files.readString(MAIN_JAVA.resolve(
+                "com/moakiee/ae2lt/mixin/BroadcastFrequencyBandMixin.java"));
+        assertFalse(mixin.contains("catch (IllegalStateException"));
+        assertFalse(mixin.contains("GridConnection.create"));
+        assertFalse(mixin.contains("Throwable"));
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/PhysicalGridClusterTest.java
+++ b/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/PhysicalGridClusterTest.java
@@ -2,6 +2,8 @@ package com.moakiee.ae2lt.grid.wirelesslink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import appeng.api.networking.IGridConnection;
@@ -68,6 +70,34 @@ class PhysicalGridClusterTest {
         connect(c, a, true);
 
         assertEquals(3, PhysicalGridCluster.collect(a).size());
+    }
+
+    @Test
+    void reusesExistingVirtualConnectionByEndpointIdentity() {
+        var target = node("target");
+        var transmitter = node("transmitter");
+        var existing = connect(target, transmitter, false);
+
+        var result = WirelessLinkOps.createVirtualConnection(target, transmitter);
+
+        assertSame(existing, result);
+        assertTrue(WirelessLinkOps.isWirelessBridge(existing));
+        assertEquals(1, connections.get(target).size());
+        assertEquals(1, connections.get(transmitter).size());
+    }
+
+    @Test
+    void rejectsExistingPhysicalConnectionBetweenSameEndpoints() {
+        var target = node("target");
+        var transmitter = node("transmitter");
+        var physical = connect(target, transmitter, true);
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> WirelessLinkOps.createVirtualConnection(target, transmitter));
+        assertFalse(WirelessLinkOps.isWirelessBridge(physical));
+        assertEquals(1, connections.get(target).size());
+        assertEquals(1, connections.get(transmitter).size());
     }
 
     @Test

--- a/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/WirelessConnectionOwnershipSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/grid/wirelesslink/WirelessConnectionOwnershipSourceContractTest.java
@@ -1,0 +1,54 @@
+package com.moakiee.ae2lt.grid.wirelesslink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class WirelessConnectionOwnershipSourceContractTest {
+    private static final Path MAIN_JAVA = Path.of("src/main/java");
+
+    @Test
+    void everyWirelessBridgeCreationPathUsesWirelessLinkOps() throws Exception {
+        String frequencyBinding = source(
+                "com/moakiee/ae2lt/grid/FrequencyBindingHelper.java");
+        String registry = source(
+                "com/moakiee/ae2lt/grid/wirelesslink/WirelessLinkRegistry.java");
+
+        assertEquals(1, occurrences(frequencyBinding, "WirelessLinkOps.createVirtualConnection("));
+        assertEquals(2, occurrences(registry, "WirelessLinkOps.createVirtualConnection("));
+        assertFalse(frequencyBinding.contains("GridConnection.create("));
+        assertFalse(frequencyBinding.contains("GridHelper.createConnection("));
+        assertFalse(registry.contains("GridConnection.create("));
+        assertFalse(registry.contains("GridHelper.createConnection("));
+    }
+
+    @Test
+    void ae2CoreConnectionCreationIsNotGloballyRewritten() throws Exception {
+        try (Stream<Path> files = Files.walk(MAIN_JAVA.resolve("com/moakiee/ae2lt/mixin"))) {
+            for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+                String mixin = Files.readString(file);
+                assertFalse(mixin.contains("targets = \"appeng.me.GridConnection\""), file.toString());
+                assertFalse(mixin.contains("targets = \"appeng.api.networking.GridHelper\""), file.toString());
+            }
+        }
+
+        String ops = source("com/moakiee/ae2lt/grid/wirelesslink/WirelessLinkOps.java");
+        assertTrue(ops.contains("catch (IllegalStateException duplicateCandidate)"));
+        assertTrue(ops.contains("throw duplicateCandidate;"));
+        assertTrue(ops.contains("isDuplicateConnectionFailure(duplicateCandidate)"));
+        assertEquals(1, occurrences(ops, "GridConnection.create("));
+    }
+
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(MAIN_JAVA.resolve(relativePath));
+    }
+
+    private static int occurrences(String source, String needle) {
+        return (source.length() - source.replace(needle, "").length()) / needle.length();
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/item/ResearchNoteBookOpeningSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/item/ResearchNoteBookOpeningSourceContractTest.java
@@ -1,0 +1,114 @@
+package com.moakiee.ae2lt.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+class ResearchNoteBookOpeningSourceContractTest {
+    @Test
+    void generatedNotesUseTheServerSnapshotPacketInsteadOfTheVanillaBookPacket() throws Exception {
+        String item = source("src/main/java/com/moakiee/ae2lt/item/ResearchNoteItem.java");
+        String generatedBranch = item.substring(
+                item.indexOf("// 已生成笔记:"),
+                item.indexOf("@Override", item.indexOf("// 已生成笔记:")));
+
+        int rebuild = generatedBranch.indexOf("applyGeneratedState(heldStack, data)");
+        int snapshot = generatedBranch.indexOf("new OpenResearchNotePacket(heldStack.copy())");
+
+        assertFalse(item.contains("ClientboundOpenBookPacket"));
+        assertTrue(rebuild >= 0, "Legacy notes must have their written-book NBT rebuilt");
+        assertTrue(snapshot > rebuild, "The server must send the rebuilt ItemStack snapshot");
+        assertTrue(generatedBranch.contains("PacketSender.sendToPlayer(serverPlayer,"));
+    }
+
+    @Test
+    void packetAndBridgeRemainCommonSideWhileTheBootstrapOpensWrittenBookAccess() throws Exception {
+        String packet = source("src/main/java/com/moakiee/ae2lt/network/OpenResearchNotePacket.java");
+        String bridge = source("src/main/java/com/moakiee/ae2lt/network/ResearchNoteClientBridge.java");
+        String bootstrap = source("src/main/java/com/moakiee/ae2lt/client/ResearchNoteClientBootstrap.java");
+        String clientInit = source("src/main/java/com/moakiee/ae2lt/client/LightningKeyClientInit.java");
+
+        assertFalse(packet.contains("net.minecraft.client"));
+        assertFalse(packet.contains("com.moakiee.ae2lt.client"));
+        assertFalse(bridge.contains("net.minecraft.client"));
+        assertFalse(bridge.contains("com.moakiee.ae2lt.client"));
+        assertTrue(packet.contains("ResearchNoteClientBridge.open(packet.book())"));
+        assertTrue(bootstrap.contains("book.getItem() instanceof ResearchNoteItem"));
+        assertTrue(bootstrap.contains("new BookViewScreen.WrittenBookAccess(book)"));
+        assertFalse(bootstrap.contains("BookAccess.fromItem"));
+        assertTrue(clientInit.contains("ResearchNoteClientBootstrap.install()"));
+    }
+
+    @Test
+    void openPacketIsAppendedAsAClientboundProtocolThreeMessage() throws Exception {
+        String network = source("src/main/java/com/moakiee/ae2lt/network/NetworkInit.java");
+        List<String> expectedOrder = List.of(
+                "WirelessConnectorUsePacket",
+                "FrequencyCardUsePacket",
+                "ToggleFrequencyCardAutoConnectPacket",
+                "MatrixControllerActionPacket",
+                "TianshuControllerActionPacket",
+                "OpenFrequencyMenuPacket",
+                "CreateFrequencyPacket",
+                "DeleteFrequencyPacket",
+                "EditFrequencyPacket",
+                "SelectFrequencyPacket",
+                "ChangeMemberPacket",
+                "EasterEggPacket",
+                "SyncFrequencyListPacket",
+                "SyncFrequencyDetailPacket",
+                "UpdateFrequencyBasicPacket",
+                "FrequencyResponsePacket",
+                "PigmeeAssemblerAnimationPacket",
+                "RitualItemBurstPacket",
+                "CelestweaveSubmoduleActivePacket",
+                "FlightInertiaSyncPacket",
+                "PhaseLockProtectionSyncPacket",
+                "ShieldHitFeedbackSuppressionPacket",
+                "RailgunBeamTogglePacket",
+                "RailgunFirePacket",
+                "RailgunBeamUpdatePacket",
+                "RailgunBeamChainFxPacket",
+                "RailgunRecoilFxPacket",
+                "DashPacket",
+                "PhaseFlightInputPacket",
+                "OpenDeviceHubPacket",
+                "DeviceHubActionPacket",
+                "DeviceHubSyncPacket",
+                "OpenMaintenanceEditorPacket",
+                "SaveMaintenanceRulePacket",
+                "SaveGlobalReservePacket",
+                "RequestUploadTargetsPacket",
+                "RequestClosedLoopResultPagePacket",
+                "UploadPatternToTargetPacket",
+                "MaintenanceEditorSyncPacket",
+                "MaintenanceSummarySyncPacket",
+                "UploadTargetsSyncPacket",
+                "ClosedLoopResultPagePacket",
+                "OpenResearchNotePacket");
+        var matcher = Pattern.compile("(?m)^\\s+([A-Za-z0-9]+Packet)\\.class,$").matcher(network);
+        List<String> actualOrder = new ArrayList<>();
+        while (matcher.find()) {
+            actualOrder.add(matcher.group(1));
+        }
+        int openPacket = network.indexOf("OpenResearchNotePacket.class");
+        int direction = network.indexOf("Optional.of(NetworkDirection.PLAY_TO_CLIENT)", openPacket);
+
+        assertTrue(network.contains("PROTOCOL_VERSION = \"3\""));
+        assertTrue(direction > openPacket, "The research-note packet must only travel to clients");
+        assertEquals(expectedOrder, actualOrder,
+                "Existing packet discriminators must remain stable and the new packet must stay last");
+    }
+
+    private static String source(String path) throws Exception {
+        return Files.readString(Path.of(path));
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/item/ResearchNoteItemTest.java
+++ b/src/test/java/com/moakiee/ae2lt/item/ResearchNoteItemTest.java
@@ -1,0 +1,84 @@
+package com.moakiee.ae2lt.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.WrittenBookItem;
+
+import com.moakiee.ae2lt.logic.research.ResearchNoteData;
+import com.moakiee.ae2lt.logic.research.RitualGoal;
+
+class ResearchNoteItemTest {
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void generatedStateProducesAValidFivePageWrittenBookPayload() {
+        ItemStack stack = new ItemStack(Items.PAPER);
+        ResearchNoteData data = noteData(false);
+
+        ResearchNoteItem.applyGeneratedState(stack, data);
+
+        assertEquals(data, ResearchNoteData.read(stack));
+        var tag = stack.getTag();
+        assertNotNull(tag);
+        assertTrue(WrittenBookItem.makeSureTagIsValid(tag));
+        assertTrue(tag.getString(WrittenBookItem.TAG_TITLE).length() <= 32);
+        assertTrue(tag.contains(WrittenBookItem.TAG_AUTHOR, Tag.TAG_STRING));
+        assertEquals(0, tag.getInt(WrittenBookItem.TAG_GENERATION));
+        assertTrue(tag.getBoolean(WrittenBookItem.TAG_RESOLVED));
+
+        var pages = tag.getList(WrittenBookItem.TAG_PAGES, Tag.TAG_STRING);
+        assertEquals(5, pages.size());
+        for (int i = 0; i < pages.size(); i++) {
+            assertNotNull(Component.Serializer.fromJson(pages.getString(i)));
+        }
+    }
+
+    @Test
+    void rebuildingACompletedNoteReplacesPagesInsteadOfAccumulatingThem() {
+        ItemStack stack = new ItemStack(Items.PAPER);
+        ResearchNoteItem.applyGeneratedState(stack, noteData(false));
+
+        ResearchNoteData completed = noteData(true);
+        ResearchNoteItem.applyGeneratedState(stack, completed);
+
+        assertEquals(completed, ResearchNoteData.read(stack));
+        var pages = stack.getTag().getList(WrittenBookItem.TAG_PAGES, Tag.TAG_STRING);
+        assertEquals(5, pages.size());
+        assertTrue(pages.getString(4).contains("ae2lt.research_note.page.completed"));
+    }
+
+    private static ResearchNoteData noteData(boolean consumed) {
+        List<ResourceLocation> recipeItems = IntStream.range(0, 9)
+                .mapToObj(index -> new ResourceLocation("minecraft", "stone_" + index))
+                .toList();
+        List<String> descriptions = IntStream.range(0, 9)
+                .mapToObj(index -> "ae2lt.research_note.test." + index)
+                .toList();
+        return new ResearchNoteData(
+                UUID.fromString("12345678-1234-5678-9abc-def012345678"),
+                RitualGoal.HYPERDIMENSIONAL_PIGMEE,
+                recipeItems,
+                descriptions,
+                consumed);
+    }
+}

--- a/src/test/java/com/moakiee/ae2lt/network/OpenResearchNotePacketTest.java
+++ b/src/test/java/com/moakiee/ae2lt/network/OpenResearchNotePacketTest.java
@@ -1,0 +1,42 @@
+package com.moakiee.ae2lt.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.SharedConstants;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+class OpenResearchNotePacketTest {
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void codecPreservesTheServerBookSnapshot() {
+        ItemStack book = new ItemStack(Items.PAPER, 3);
+        book.getOrCreateTag().putString("title", "Research Note #A1B2");
+        book.getOrCreateTag().putBoolean("resolved", true);
+        OpenResearchNotePacket packet = new OpenResearchNotePacket(book);
+        FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
+
+        try {
+            packet.write(buffer);
+            OpenResearchNotePacket decoded = OpenResearchNotePacket.decode(buffer);
+
+            assertEquals(book.getCount(), decoded.book().getCount());
+            assertTrue(ItemStack.isSameItemSameTags(book, decoded.book()));
+            assertEquals(0, buffer.readableBytes());
+        } finally {
+            buffer.release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix Phase Lock movement and teleport authorization regressions, GuideME tooltip ownership, projection synchronization churn, and duplicate AE2 wireless receiver connections that can shut down the server when linking an AE2 Crystal Science Ender Broadcaster with an overloaded frequency card.

## Changes

- Keep the four Phase Lock options independent, with safe false defaults.
- Restore vanilla autonomous movement mutations in water, bubble columns, lava, and powder snow without authorizing arbitrary third-party movement code.
- Preserve explicit player-initiated teleport authorization, including map teleport flows.
- Restrict GuideME `item_ids` ownership checks to canonical AE2LT declarations while retaining valid body `ItemLink` references.
- Avoid rewriting unchanged Phase Lock projection enchantment data every tick.
- Make AE2LT virtual wireless bridge creation endpoint-identity based and idempotent while preserving physical connection errors.
- Add an optional `ae2cs`-gated compatibility Mixin for the exact `BroadcastFrequencyBand.applyReceiver` duplicate receiver-connection call.
- Add regression and source-contract tests for movement, configuration, projection synchronization, wireless connection ownership, and AE2CS compatibility boundaries.

## Testing

- Complete JUnit suite passed.
- Offline Gradle `build` passed.
- Beta6 artifact build passed with version `2.1.0-beta.6`.
- `git diff --check` passed.
- AE2CS 1.20.1-1.2.0 source and bytecode were inspected to verify the exact private method descriptor and single connection call site.
