### PR TITLE
fix: support Forge 47.4 fluid movement mixins

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
@@ -5,8 +5,8 @@ import java.util.function.BiConsumer;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
-import org.apache.commons.lang3.tuple.MutableTriple;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,9 +18,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
-
-import net.minecraftforge.common.ForgeMod;
-import net.minecraftforge.fluids.FluidType;
 
 import com.moakiee.ae2lt.celestweave.PhaseFlightControlRules;
 import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
@@ -50,24 +47,53 @@ public abstract class EntityPhaseMovementMixin {
                     value = "INVOKE",
                     target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V",
                     remap = false),
-            remap = false)
+            remap = false,
+            require = 0)
+    private void ae2lt$authorizeLegacyVanillaFluidPushes(
+            Object2ObjectMap<?, ?> fluidData,
+            BiConsumer<?, ?> consumer,
+            Operation<Void> original) {
+        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
+    }
+
+    @WrapOperation(
+            method = {
+                "updateFluidHeightAndDoFluidPushing()V",
+                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"
+            },
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;forEach(Ljava/util/function/BiConsumer;)V",
+                    remap = false),
+            remap = false,
+            require = 0)
+    private void ae2lt$authorizeModernVanillaFluidPushes(
+            Object2ObjectArrayMap<?, ?> fluidData,
+            BiConsumer<?, ?> consumer,
+            Operation<Void> original) {
+        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void ae2lt$authorizeVanillaFluidPushes(
-            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> fluidData,
-            BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>> consumer,
+            Object fluidData,
+            BiConsumer consumer,
             Operation<Void> original) {
         Player player = (Object) this instanceof Player currentPlayer ? currentPlayer : null;
-        original.call(fluidData, (BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>>)
-                (fluidType, data) -> {
-                    if (player != null
-                            && (fluidType == ForgeMod.WATER_TYPE.get()
-                                    || fluidType == ForgeMod.LAVA_TYPE.get())) {
-                        PhaseFlightMovementGuard.runAsEnvironmentMovement(
-                                player,
-                                () -> consumer.accept(fluidType, data));
-                    } else {
-                        consumer.accept(fluidType, data);
-                    }
-                });
+        original.call(fluidData, (BiConsumer<Object, Object>) (fluidType, data) -> {
+            if (player != null && isVanillaFluidType(fluidType)) {
+                PhaseFlightMovementGuard.runAsEnvironmentMovement(
+                        player,
+                        () -> consumer.accept(fluidType, data));
+            } else {
+                consumer.accept(fluidType, data);
+            }
+        });
+    }
+
+    private static boolean isVanillaFluidType(Object fluidType) {
+        return fluidType == net.minecraftforge.common.ForgeMod.WATER_TYPE.get()
+                || fluidType == net.minecraftforge.common.ForgeMod.LAVA_TYPE.get();
     }
 
     @WrapMethod(method = "onAboveBubbleCol(Z)V")

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
@@ -39,18 +39,22 @@ final class PhaseEnvironmentMovementSourceContractTest {
         String mixin = Files.readString(Path.of(
                 "src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java"));
 
-        assertTrue(mixin.contains("updateFluidHeightAndDoFluidPushing()V"));
+        assertTrue(mixin.contains("\"updateFluidHeightAndDoFluidPushing()V\""));
         assertTrue(mixin.contains(
-                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"));
+                "\"updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V\""));
+        assertTrue(mixin.contains("@WrapOperation"));
         assertTrue(mixin.contains("Object2ObjectMap;forEach"));
+        assertTrue(mixin.contains("Object2ObjectArrayMap;forEach"));
+        assertTrue(mixin.contains("remap = false"));
+        assertTrue(mixin.contains("require = 0"));
+        assertFalse(mixin.contains("MutableTriple"));
+        assertFalse(mixin.contains("FluidCalcs"));
         assertFalse(mixin.contains("lambda$updateFluidHeightAndDoFluidPushing$"));
-        assertTrue(mixin.contains("fluidType == ForgeMod.WATER_TYPE.get()"));
-        assertTrue(mixin.contains("fluidType == ForgeMod.LAVA_TYPE.get()"));
+        assertTrue(mixin.contains("ForgeMod.WATER_TYPE.get()"));
+        assertTrue(mixin.contains("ForgeMod.LAVA_TYPE.get()"));
         assertTrue(mixin.contains("onAboveBubbleCol(Z)V"));
         assertTrue(mixin.contains("onInsideBubbleColumn(Z)V"));
         assertTrue(mixin.contains("PhaseFlightMovementGuard.runAsEnvironmentMovement"));
-        assertFalse(mixin.contains("isInWater()"));
-        assertFalse(mixin.contains("isInLava()"));
         assertFalse(mixin.contains("isFreezing()"));
     }
 


### PR DESCRIPTION
## Summary

Prevent Phase Lock from crashing Minecraft during startup on Forge 47.4.x.

## Changes

- Replace the single Forge-internal fluid map injection with optional compatibility wrappers for both `Object2ObjectMap.forEach` and `Object2ObjectArrayMap.forEach`.
- Use erased callback value types so the mixin does not depend on Forge's version-specific `MutableTriple` or `Entity$FluidCalcs` implementation.
- Keep environment authorization limited to vanilla water and lava fluid entries.
- Update the source contract test for both Forge layouts.
- `gradle.properties` is intentionally excluded from this PR.

## Testing

- `./gradlew clean test build --no-daemon --offline -I ../.scratch/local-init.gradle` passed on the development Forge 47.1.47 setup.
- The resulting beta6 artifact was verified to contain the updated mixin class.
- Forge 47.4.x runtime smoke testing was blocked locally by unavailable offline ASM 9.9.1 artifacts; the reported old callback is no longer present in the rebuilt JAR.
