### PR TITLE
fix: preserve Phase Lock semantics on Forge 47.4

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java
@@ -31,8 +31,6 @@ public final class PhaseFlightMovementGuard {
     private static final ThreadLocal<ServerPlayer> MAIN_THREAD_PAYLOAD_PLAYER = new ThreadLocal<>();
     private static final ThreadLocal<IdentityHashMap<Player, Integer>> MOVEMENT_POSITION_UPDATE_DEPTH =
             ThreadLocal.withInitial(IdentityHashMap::new);
-    private static final ThreadLocal<IdentityHashMap<Player, Integer>> ENVIRONMENT_MOVEMENT_DEPTH =
-            ThreadLocal.withInitial(IdentityHashMap::new);
     private static final ThreadLocal<IdentityHashMap<Player, Integer>> VANILLA_TRAVEL_MOVEMENT_DEPTH =
             ThreadLocal.withInitial(IdentityHashMap::new);
     private static final ThreadLocal<IdentityHashMap<Player, Integer>> VANILLA_TRAVEL_SCOPE_DEPTH =
@@ -110,7 +108,6 @@ public final class PhaseFlightMovementGuard {
             MAIN_THREAD_PAYLOAD_PLAYER.remove();
         }
         MOVEMENT_POSITION_UPDATE_DEPTH.get().remove(player);
-        ENVIRONMENT_MOVEMENT_DEPTH.get().remove(player);
         VANILLA_TRAVEL_MOVEMENT_DEPTH.get().remove(player);
         VANILLA_TRAVEL_SCOPE_DEPTH.get().remove(player);
         if (MOVEMENT_PACKET_PLAYER.get() == player) {
@@ -178,8 +175,7 @@ public final class PhaseFlightMovementGuard {
         if (player == null) {
             return false;
         }
-        if (SELF_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0
-                || ENVIRONMENT_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0) {
+        if (SELF_MOVEMENT_DEPTH.get().getOrDefault(player, 0) > 0) {
             return true;
         }
         if (consumeVanillaTravelMovement(player)) {
@@ -295,30 +291,6 @@ public final class PhaseFlightMovementGuard {
             endSelfMovement(player);
         }
     }
-
-    /** Runs only the original fluid and bubble-column velocity updates for this player. */
-    public static void runAsEnvironmentMovement(Player player, Runnable movement) {
-        if (player == null) {
-            movement.run();
-            return;
-        }
-        var depths = ENVIRONMENT_MOVEMENT_DEPTH.get();
-        depths.merge(player, 1, Integer::sum);
-        try {
-            movement.run();
-        } finally {
-            int next = depths.getOrDefault(player, 0) - 1;
-            if (next <= 0) {
-                depths.remove(player);
-                if (depths.isEmpty()) {
-                    ENVIRONMENT_MOVEMENT_DEPTH.remove();
-                }
-            } else {
-                depths.put(player, next);
-            }
-        }
-    }
-
 
     /** Authorizes one direct vanilla travel mutation without authorizing nested third-party code. */
     public static void runAsVanillaTravelMovement(Player player, Runnable movement) {

--- a/src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java
+++ b/src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java
@@ -207,7 +207,7 @@ public final class PhaseLockSubmodule extends AbstractCelestweaveArmorSubmodule 
             case ARMOR_LOCK_CONFIG_KEY,
                     FLIGHT_LOCK_CONFIG_KEY,
                     BLOCK_EXTERNAL_FORCES_CONFIG_KEY,
-                    BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> false;
+                    BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> true;
             default -> false;
         };
     }

--- a/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
@@ -1,12 +1,8 @@
 package com.moakiee.ae2lt.mixin;
 
-import java.util.function.BiConsumer;
-
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -36,86 +32,6 @@ public abstract class EntityPhaseMovementMixin {
                         player.isShiftKeyDown())) {
             cir.setReturnValue(true);
         }
-    }
-
-    @WrapOperation(
-            method = {
-                "updateFluidHeightAndDoFluidPushing()V",
-                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"
-            },
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V",
-                    remap = false),
-            remap = false,
-            require = 0)
-    private void ae2lt$authorizeLegacyVanillaFluidPushes(
-            Object2ObjectMap<?, ?> fluidData,
-            BiConsumer<?, ?> consumer,
-            Operation<Void> original) {
-        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
-    }
-
-    @WrapOperation(
-            method = {
-                "updateFluidHeightAndDoFluidPushing()V",
-                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"
-            },
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;forEach(Ljava/util/function/BiConsumer;)V",
-                    remap = false),
-            remap = false,
-            require = 0)
-    private void ae2lt$authorizeModernVanillaFluidPushes(
-            Object2ObjectArrayMap<?, ?> fluidData,
-            BiConsumer<?, ?> consumer,
-            Operation<Void> original) {
-        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private void ae2lt$authorizeVanillaFluidPushes(
-            Object fluidData,
-            BiConsumer consumer,
-            Operation<Void> original) {
-        Player player = (Object) this instanceof Player currentPlayer ? currentPlayer : null;
-        original.call(fluidData, (BiConsumer<Object, Object>) (fluidType, data) -> {
-            if (player != null && isVanillaFluidType(fluidType)) {
-                PhaseFlightMovementGuard.runAsEnvironmentMovement(
-                        player,
-                        () -> consumer.accept(fluidType, data));
-            } else {
-                consumer.accept(fluidType, data);
-            }
-        });
-    }
-
-    private static boolean isVanillaFluidType(Object fluidType) {
-        return fluidType == net.minecraftforge.common.ForgeMod.WATER_TYPE.get()
-                || fluidType == net.minecraftforge.common.ForgeMod.LAVA_TYPE.get();
-    }
-
-    @WrapMethod(method = "onAboveBubbleCol(Z)V")
-    private void ae2lt$authorizeAboveBubbleMovement(boolean dragDown, Operation<Void> original) {
-        if ((Object) this instanceof Player player) {
-            PhaseFlightMovementGuard.runAsEnvironmentMovement(
-                    player,
-                    () -> original.call(dragDown));
-            return;
-        }
-        original.call(dragDown);
-    }
-
-    @WrapMethod(method = "onInsideBubbleColumn(Z)V")
-    private void ae2lt$authorizeInsideBubbleMovement(boolean dragDown, Operation<Void> original) {
-        if ((Object) this instanceof Player player) {
-            PhaseFlightMovementGuard.runAsEnvironmentMovement(
-                    player,
-                    () -> original.call(dragDown));
-            return;
-        }
-        original.call(dragDown);
     }
 
     @WrapOperation(

--- a/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java
@@ -5,8 +5,8 @@ import java.util.function.BiConsumer;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
-import org.apache.commons.lang3.tuple.MutableTriple;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,9 +18,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
-
-import net.minecraftforge.common.ForgeMod;
-import net.minecraftforge.fluids.FluidType;
 
 import com.moakiee.ae2lt.celestweave.PhaseFlightControlRules;
 import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
@@ -50,24 +47,53 @@ public abstract class EntityPhaseMovementMixin {
                     value = "INVOKE",
                     target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V",
                     remap = false),
-            remap = false)
+            remap = false,
+            require = 0)
+    private void ae2lt$authorizeLegacyVanillaFluidPushes(
+            Object2ObjectMap<?, ?> fluidData,
+            BiConsumer<?, ?> consumer,
+            Operation<Void> original) {
+        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
+    }
+
+    @WrapOperation(
+            method = {
+                "updateFluidHeightAndDoFluidPushing()V",
+                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"
+            },
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;forEach(Ljava/util/function/BiConsumer;)V",
+                    remap = false),
+            remap = false,
+            require = 0)
+    private void ae2lt$authorizeModernVanillaFluidPushes(
+            Object2ObjectArrayMap<?, ?> fluidData,
+            BiConsumer<?, ?> consumer,
+            Operation<Void> original) {
+        ae2lt$authorizeVanillaFluidPushes(fluidData, consumer, original);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void ae2lt$authorizeVanillaFluidPushes(
-            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> fluidData,
-            BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>> consumer,
+            Object fluidData,
+            BiConsumer consumer,
             Operation<Void> original) {
         Player player = (Object) this instanceof Player currentPlayer ? currentPlayer : null;
-        original.call(fluidData, (BiConsumer<FluidType, MutableTriple<Double, Vec3, Integer>>)
-                (fluidType, data) -> {
-                    if (player != null
-                            && (fluidType == ForgeMod.WATER_TYPE.get()
-                                    || fluidType == ForgeMod.LAVA_TYPE.get())) {
-                        PhaseFlightMovementGuard.runAsEnvironmentMovement(
-                                player,
-                                () -> consumer.accept(fluidType, data));
-                    } else {
-                        consumer.accept(fluidType, data);
-                    }
-                });
+        original.call(fluidData, (BiConsumer<Object, Object>) (fluidType, data) -> {
+            if (player != null && isVanillaFluidType(fluidType)) {
+                PhaseFlightMovementGuard.runAsEnvironmentMovement(
+                        player,
+                        () -> consumer.accept(fluidType, data));
+            } else {
+                consumer.accept(fluidType, data);
+            }
+        });
+    }
+
+    private static boolean isVanillaFluidType(Object fluidType) {
+        return fluidType == net.minecraftforge.common.ForgeMod.WATER_TYPE.get()
+                || fluidType == net.minecraftforge.common.ForgeMod.LAVA_TYPE.get();
     }
 
     @WrapMethod(method = "onAboveBubbleCol(Z)V")

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
@@ -39,18 +39,22 @@ final class PhaseEnvironmentMovementSourceContractTest {
         String mixin = Files.readString(Path.of(
                 "src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java"));
 
-        assertTrue(mixin.contains("updateFluidHeightAndDoFluidPushing()V"));
+        assertTrue(mixin.contains("\"updateFluidHeightAndDoFluidPushing()V\""));
         assertTrue(mixin.contains(
-                "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V"));
+                "\"updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V\""));
+        assertTrue(mixin.contains("@WrapOperation"));
         assertTrue(mixin.contains("Object2ObjectMap;forEach"));
+        assertTrue(mixin.contains("Object2ObjectArrayMap;forEach"));
+        assertTrue(mixin.contains("remap = false"));
+        assertTrue(mixin.contains("require = 0"));
+        assertFalse(mixin.contains("MutableTriple"));
+        assertFalse(mixin.contains("FluidCalcs"));
         assertFalse(mixin.contains("lambda$updateFluidHeightAndDoFluidPushing$"));
-        assertTrue(mixin.contains("fluidType == ForgeMod.WATER_TYPE.get()"));
-        assertTrue(mixin.contains("fluidType == ForgeMod.LAVA_TYPE.get()"));
+        assertTrue(mixin.contains("ForgeMod.WATER_TYPE.get()"));
+        assertTrue(mixin.contains("ForgeMod.LAVA_TYPE.get()"));
         assertTrue(mixin.contains("onAboveBubbleCol(Z)V"));
         assertTrue(mixin.contains("onInsideBubbleColumn(Z)V"));
         assertTrue(mixin.contains("PhaseFlightMovementGuard.runAsEnvironmentMovement"));
-        assertFalse(mixin.contains("isInWater()"));
-        assertFalse(mixin.contains("isInLava()"));
         assertFalse(mixin.contains("isFreezing()"));
     }
 

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseEnvironmentMovementSourceContractTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 
 final class PhaseEnvironmentMovementSourceContractTest {
     @Test
-    void forceScopesArePlayerBoundFinallySafeAndSeparatedFromTeleport() throws Exception {
+    void forceAuthorizationIsPlayerBoundFinallySafeAndSeparatedFromTeleport() throws Exception {
         String guard = Files.readString(Path.of(
                 "src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java"));
 
-        assertTrue(guard.contains("ENVIRONMENT_MOVEMENT_DEPTH"));
-        assertTrue(guard.contains("runAsEnvironmentMovement(Player player, Runnable movement)"));
+        assertFalse(guard.contains("ENVIRONMENT_MOVEMENT_DEPTH"));
+        assertFalse(guard.contains("runAsEnvironmentMovement"));
         assertTrue(guard.contains("VANILLA_TRAVEL_MOVEMENT_DEPTH"));
         assertTrue(guard.contains("runAsVanillaTravelMovement(Player player, Runnable movement)"));
         assertTrue(guard.contains("consumeVanillaTravelMovement(player)"));
@@ -30,32 +30,23 @@ final class PhaseEnvironmentMovementSourceContractTest {
                 guard,
                 "public static boolean isSelfTeleportAuthorized",
                 "private static boolean isPrivilegedCommandExecution");
-        assertFalse(teleportAuthorization.contains("ENVIRONMENT_MOVEMENT_DEPTH"));
         assertFalse(teleportAuthorization.contains("VANILLA_TRAVEL_MOVEMENT_DEPTH"));
     }
 
     @Test
-    void vanillaFluidAndBubbleSourcesUseNarrowEnvironmentScopes() throws Exception {
+    void fluidAndBubbleForcesRemainExternal() throws Exception {
         String mixin = Files.readString(Path.of(
                 "src/main/java/com/moakiee/ae2lt/mixin/EntityPhaseMovementMixin.java"));
 
-        assertTrue(mixin.contains("\"updateFluidHeightAndDoFluidPushing()V\""));
-        assertTrue(mixin.contains(
-                "\"updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V\""));
-        assertTrue(mixin.contains("@WrapOperation"));
-        assertTrue(mixin.contains("Object2ObjectMap;forEach"));
-        assertTrue(mixin.contains("Object2ObjectArrayMap;forEach"));
-        assertTrue(mixin.contains("remap = false"));
-        assertTrue(mixin.contains("require = 0"));
-        assertFalse(mixin.contains("MutableTriple"));
-        assertFalse(mixin.contains("FluidCalcs"));
-        assertFalse(mixin.contains("lambda$updateFluidHeightAndDoFluidPushing$"));
-        assertTrue(mixin.contains("ForgeMod.WATER_TYPE.get()"));
-        assertTrue(mixin.contains("ForgeMod.LAVA_TYPE.get()"));
-        assertTrue(mixin.contains("onAboveBubbleCol(Z)V"));
-        assertTrue(mixin.contains("onInsideBubbleColumn(Z)V"));
-        assertTrue(mixin.contains("PhaseFlightMovementGuard.runAsEnvironmentMovement"));
-        assertFalse(mixin.contains("isFreezing()"));
+        assertFalse(mixin.contains("updateFluidHeightAndDoFluidPushing"));
+        assertFalse(mixin.contains("Object2ObjectMap;forEach"));
+        assertFalse(mixin.contains("Object2ObjectArrayMap;forEach"));
+        assertFalse(mixin.contains("ForgeMod.WATER_TYPE.get()"));
+        assertFalse(mixin.contains("ForgeMod.LAVA_TYPE.get()"));
+        assertFalse(mixin.contains("onAboveBubbleCol"));
+        assertFalse(mixin.contains("onInsideBubbleColumn"));
+        assertFalse(mixin.contains("runAsEnvironmentMovement"));
+        assertTrue(mixin.contains("PhaseFlightMovementGuard.blocksExternalForces(player)"));
     }
 
     @Test

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseLockSubmoduleSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseLockSubmoduleSourceContractTest.java
@@ -8,12 +8,26 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
+import com.moakiee.ae2lt.celestweave.module.PhaseLockSubmodule;
+
 final class PhaseLockSubmoduleSourceContractTest {
     private static final Path SOURCE = Path.of(
             "src/main/java/com/moakiee/ae2lt/celestweave/module/PhaseLockSubmodule.java");
 
     @Test
-    void everyFeatureHasAnExplicitIndependentDefault() throws Exception {
+    void missingOptionsEnableTheModuleAndAllMainFeatures() throws Exception {
+        assertTrue(PhaseLockSubmodule.INSTANCE.defaultEnabled());
+        var defaultValue = PhaseLockSubmodule.class.getDeclaredMethod("defaultValue", String.class);
+        defaultValue.setAccessible(true);
+        assertTrue((boolean) defaultValue.invoke(null, PhaseLockSubmodule.ARMOR_LOCK_CONFIG_KEY));
+        assertTrue((boolean) defaultValue.invoke(null, PhaseLockSubmodule.FLIGHT_LOCK_CONFIG_KEY));
+        assertTrue((boolean) defaultValue.invoke(null, PhaseLockSubmodule.BLOCK_EXTERNAL_FORCES_CONFIG_KEY));
+        assertTrue((boolean) defaultValue.invoke(null, PhaseLockSubmodule.BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY));
+        assertFalse((boolean) defaultValue.invoke(null, "unknown"));
+    }
+
+    @Test
+    void everyFeatureDefaultsToMainProtectionSemantics() throws Exception {
         String source = Files.readString(SOURCE);
 
         int defaults = source.indexOf("private static boolean defaultValue(String key)");
@@ -22,8 +36,8 @@ final class PhaseLockSubmoduleSourceContractTest {
         assertTrue(defaultBody.contains(
                 "case ARMOR_LOCK_CONFIG_KEY, FLIGHT_LOCK_CONFIG_KEY, "
                         + "BLOCK_EXTERNAL_FORCES_CONFIG_KEY, "
-                        + "BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> false;"));
-        assertFalse(defaultBody.contains("-> true"));
+                        + "BLOCK_EXTERNAL_TELEPORTS_CONFIG_KEY -> true;"));
+        assertTrue(defaultBody.contains("default -> false;"));
         assertFalse(source.contains("!options.contains(key, Tag.TAG_BYTE) || options.getBoolean(key)"));
         assertTrue(source.contains("options.contains(key, Tag.TAG_BYTE)"));
     }


### PR DESCRIPTION
## Summary

Prevent Phase Lock from crashing Minecraft during startup on Forge 47.4.x while preserving the behavior defined by `main`: player-authorized travel remains usable, while water currents, bubble columns, knockback, fans, and other external velocity changes remain blocked when protection is enabled.

## Changes

- Remove the Forge-internal fluid `forEach` injection instead of binding the mixin to either the 47.1 `Object2ObjectMap` or 47.4 `Object2ObjectArrayMap` implementation.
- Remove the separate environment-movement authorization for water, lava, and bubble columns.
- Keep narrow, player-bound permits for direct vanilla `travel` mutations so normal player input still works without authorizing nested third-party callbacks.
- Restore the four Phase Lock feature defaults to the `main` contract: armor lock, flight lock, external-force blocking, and external-teleport blocking default to enabled when their keys are absent. Explicitly saved `false` values remain false; unknown keys remain false.
- Update source-contract and executable default-value tests.

## Testing

- Forge 47.1.47: `gradlew.bat clean test build --no-daemon --stacktrace` passed (16 tasks executed).
- Forge 47.4.20: build/reobfuscation passed with optional runtime integrations disabled.
- Forge 47.4.20: focused Phase Lock environment/default tests passed.
- Forge 47.4.20: dedicated server reached `Done (12.039s)`; logs confirm `EntityPhaseMovementMixin` applied successfully with no Mixin injection failure.