### PR TITLE
fix(celestweave): exempt creative and spectator movement speed checks

### DIFF
--- a/src/main/java/com/moakiee/ae2lt/mixin/ServerGamePacketListenerPhaseMovementMixin.java
+++ b/src/main/java/com/moakiee/ae2lt/mixin/ServerGamePacketListenerPhaseMovementMixin.java
@@ -17,6 +17,7 @@ import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.RelativeMovement;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 
 import com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuard;
@@ -63,6 +64,21 @@ public abstract class ServerGamePacketListenerPhaseMovementMixin {
             PhaseFlightMovementGuard.notifyBlockedTeleport(player, target);
             ci.cancel();
         }
+    }
+
+    @WrapOperation(
+            method = "handleMovePlayer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;isSingleplayerOwner()Z"))
+    private boolean ae2lt$allowCreativeAndSpectatorMovement(
+            ServerGamePacketListenerImpl listener,
+            Operation<Boolean> original) {
+        ServerPlayer player = ((ServerGamePacketListenerImpl) (Object) this).player;
+        GameType gameType = player.gameMode.getGameModeForPlayer();
+        return original.call(listener)
+                || gameType == GameType.CREATIVE
+                || gameType == GameType.SPECTATOR;
     }
 
     @WrapMethod(method = "handleMovePlayer")

--- a/src/test/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuardSourceContractTest.java
+++ b/src/test/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuardSourceContractTest.java
@@ -170,6 +170,26 @@ class PhaseFlightMovementGuardSourceContractTest {
     }
 
     @Test
+    void serverMovementSpeedCheckAllowsCreativeAndSpectatorPlayers() throws Exception {
+        String packetMixin = Files.readString(Path.of(
+                "src/main/java/com/moakiee/ae2lt/mixin/ServerGamePacketListenerPhaseMovementMixin.java"));
+
+        assertTrue(packetMixin.contains("@WrapOperation("));
+        assertTrue(packetMixin.contains("method = \"handleMovePlayer\""));
+        assertTrue(packetMixin.contains(
+                "target = \"Lnet/minecraft/server/network/ServerGamePacketListenerImpl;isSingleplayerOwner()Z\""));
+        assertTrue(packetMixin.contains("Operation<Boolean> original"));
+        assertTrue(packetMixin.contains("return original.call(listener)"));
+        assertTrue(packetMixin.contains("gameType == GameType.CREATIVE"));
+        assertTrue(packetMixin.contains("gameType == GameType.SPECTATOR"));
+        assertTrue(packetMixin.contains("@WrapMethod(method = \"handleMovePlayer\")"));
+        assertTrue(packetMixin.contains("PhaseFlightMovementGuard.beginMovementPacket(player)"));
+        assertTrue(packetMixin.contains("PhaseFlightMovementGuard.endMovementPacket(player)"));
+        assertTrue(packetMixin.contains("finally"));
+        assertFalse(packetMixin.contains("method = \"handlePlayerAction\""));
+    }
+
+    @Test
     void customPayloadTeleportAuthorizationIsBoundToTheSendingPlayerOnly() throws Exception {
         String guard = Files.readString(Path.of(
                 "src/main/java/com/moakiee/ae2lt/celestweave/PhaseFlightMovementGuard.java"));


### PR DESCRIPTION
## Summary

Allow creative and spectator players to bypass the vanilla `moved too quickly` branch in the server's player movement handler.

## Changes

- Wrap the `isSingleplayerOwner()` check only within `handleMovePlayer` and preserve its original result.
- Extend that narrow exemption to `GameType.CREATIVE` and `GameType.SPECTATOR`.
- Keep the existing AE2LT movement-packet authorization wrapper and its `finally` cleanup unchanged.
- Add a source contract test covering the injection target, both game modes, and the retained movement guard behavior.

Other player movement processing remains active, and this does not alter `handleMoveVehicle` or `handlePlayerAction`.

## Testing

- `git diff --check` passed.
- Targeted test command attempted: `./gradlew.bat test --tests com.moakiee.ae2lt.celestweave.PhaseFlightMovementGuardSourceContractTest --no-daemon`.
- The test did not reach compilation because ForgeGradle rejected certificate validation for `https://maven.minecraftforge.net/` while applying the plugin. No certificate or project configuration was changed.
